### PR TITLE
fix: version command

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,9 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2025-Present The Lula2 Authors
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import fs from "fs";
+import { getVersion } from "./index.js";
+
+vi.mock("fs", () => ({
+  default: {
+    readFileSync: vi.fn().mockReturnValue(JSON.stringify({ version: "1.2.3" })),
+  },
+}));
 describe("lula2", () => {
-  it("should be a placeholder test", async () => {
-    expect(true).toBe(true);
+  it("should return the current version (mocked)", () => {
+    const version = getVersion();
+    expect(version).toBe("1.2.3");
+
+    expect(fs.readFileSync).toHaveBeenCalledWith(
+      expect.stringContaining("package.json"),
+      "utf8"
+    );
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -15,9 +15,6 @@ describe("lula2", () => {
     const version = getVersion();
     expect(version).toBe("1.2.3");
 
-    expect(fs.readFileSync).toHaveBeenCalledWith(
-      expect.stringContaining("package.json"),
-      "utf8"
-    );
+    expect(fs.readFileSync).toHaveBeenCalledWith(expect.stringContaining("package.json"), "utf8");
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,8 @@ const program = new Command();
 
 /**
  * Get the current version from package.json
- * @returns {string} The current version
+ * 
+ * @returns The current version
  */
 export function getVersion(): string {
   const packageJson = fs.readFileSync(path.resolve(process.cwd(), "./package.json"), "utf8");

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ const program = new Command();
 
 /**
  * Get the current version from package.json
- * 
+ *
  * @returns The current version
  */
 export function getVersion(): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,13 +5,16 @@ import crawl from "./crawl.js";
 import fs from "fs";
 import path from "path";
 
-
 const program = new Command();
 
+/**
+ * Get the current version from package.json
+ * @returns {string} The current version
+ */
 export function getVersion(): string {
-   const packageJson = fs.readFileSync(path.resolve(process.cwd(),"./package.json"), "utf8");
-   const { version } = JSON.parse(packageJson);
-   return version
+  const packageJson = fs.readFileSync(path.resolve(process.cwd(), "./package.json"), "utf8");
+  const { version } = JSON.parse(packageJson);
+  return version;
 }
 
 program

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,22 @@
 
 import { Command } from "commander";
 import crawl from "./crawl.js";
-// Define the program
+import fs from "fs";
+import path from "path";
+
+
 const program = new Command();
 
-// Set basic information
+export function getVersion(): string {
+   const packageJson = fs.readFileSync(path.resolve(process.cwd(),"./package.json"), "utf8");
+   const { version } = JSON.parse(packageJson);
+   return version
+}
+
 program
   .name("lula2")
   .description("Reports and exports compliance status for defined controls")
+  .version(getVersion(), "-v, --version", "output the current version")
   .option("-c, --config <path>", "path to config file", "compliance.json")
   .addCommand(crawl())
   .action(options => {


### PR DESCRIPTION
## Description

The `nightlies.sh` uses a version command in order to do a nightly release but we had none

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
