### PR TITLE
feat: new keywords and sha256sum calculation on changed files

### DIFF
--- a/src/crawl.ts
+++ b/src/crawl.ts
@@ -193,7 +193,7 @@ export default function (): Command {
           const changedBlocks = getChangedBlocks(oldText, newText);
 
           for (const block of changedBlocks) {
-              const newBlockText = newText
+            const newBlockText = newText
               .split("\n")
               .slice(block.startLine, block.endLine)
               .join("\n");
@@ -202,7 +202,7 @@ export default function (): Command {
             const commentBody =
               `**Compliance Alert**:\`${file.filename}\` changed between lines ${block.startLine + 1}–${block.endLine}.` +
               `\nUUID \`${block.uuid}\` may be out of compliance.` +
-              `\nSHA-256 of block contents: \`${blockSha256}\`.` + 
+              `\nSHA-256 of block contents: \`${blockSha256}\`.` +
               `\n\n Please review the changes to ensure they meet compliance standards.`;
             console.log(`Commenting on ${file.filename}: ${commentBody}`);
             await octokit.issues.createComment({


### PR DESCRIPTION
## Description

This PR changes the `mapStart/mapEnd` keywords to `lulaStart/lulaEnd` and generates a sha256sum on the lines that changed.

**Usage:**

```bash
OWNER=defenseunicorns REPO=pepr-excellent-examples PULL_NUMBER=374 GITHUB_TOKEN=$(gh auth token) npx tsx src/index.ts crawl
```

[Example PR](https://github.com/defenseunicorns/pepr-excellent-examples/pull/374/) in PEXEX where comments are made.

## Related Issue

Fixes #31 

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
