### PR TITLE
chore: override vulnerable npm libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,13 @@
     "typescript-eslint": "^8.41.0",
     "vitest": "^3.2.4"
   },
+  "overrides": {
+    "backslash": "0.2.1",
+    "chalk-template": "1.1.1",
+    "color-string": "2.1.1",
+    "slice-ansi": "7.1.1",
+    "simple-swizzle": "0.2.3"
+  },
   "release": {
     "branches": [
       "main",


### PR DESCRIPTION
## Description

Overrides vulnerable npm libraries so we do not get them through dependabot

https://socket.dev/blog/npm-author-qix-compromised-in-major-supply-chain-attack

_Many_ of these packages have already removed the vulnerable versions.

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
