### PR TITLE
chore: override vulnerable npm libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "backslash": "0.2.1",
     "chalk-template": "1.1.1",
     "color-string": "2.1.1",
-    "slice-ansi": "7.1.1",
     "simple-swizzle": "0.2.3"
   },
   "release": {


### PR DESCRIPTION
## Description

They removed the vulnerable version of slice ansi and we need to remove it from overrides for npm install will not work 

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
