### PR TITLE
fix: pnpm ci not implemented

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         run: pnpm store path | xargs -I{} mkdir -p "{}"
 
       - name: Install dependencies
-        run: pnpm ci
+        run: pnpm i
 
       - name: Build
         run: pnpm run build


### PR DESCRIPTION
## Description
`pnpm ci` is not implemented

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
