### PR TITLE
fix: package.json names

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/defenseunicorns/lula-next.git"
+		"url": "git+https://github.com/defenseunicorns/lula.git"
 	},
 	"keywords": [
 		"compliance",
@@ -23,9 +23,9 @@
 	"author": "Defense Unicorns",
 	"license": "Apache-2.0",
 	"bugs": {
-		"url": "https://github.com/defenseunicorns/lula-next/issues"
+		"url": "https://github.com/defenseunicorns/lula/issues"
 	},
-	"homepage": "https://github.com/defenseunicorns/lula-next#readme",
+	"homepage": "https://github.com/defenseunicorns/lula#readme",
 	"files": [
 		"/src",
 		"/dist",


### PR DESCRIPTION
## Description

the package.json is still showing `lula-next` which is blocking the release

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
