### PR TITLE
fix: dist path for index fix after express bump

### DIFF
--- a/cli/server/server.ts
+++ b/cli/server/server.ts
@@ -57,7 +57,7 @@ export async function createServer(options: ServerOptions): Promise<{
 
 	// Serve frontend for all other routes (SPA fallback)
 	app.get('/*splat', (req, res) => {
-		res.sendFile(join(distPath, 'index.html'));
+		res.sendFile('index.html', { root: distPath });
 	});
 
 	// Create HTTP server for both Express and WebSocket


### PR DESCRIPTION
## Description

The `index.html` file was not found after express changed their support for wildcard syntax. This should fix it

## Related Issue

Fixes #86 

<!-- or -->

Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
