### PR TITLE
chore: mock stderr for clean test output

### DIFF
--- a/cli/server/infrastructure/controlHelpers.test.ts
+++ b/cli/server/infrastructure/controlHelpers.test.ts
@@ -3,7 +3,7 @@
 
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Control } from '../types';
 import {
 	clearMetadataCache,
@@ -69,10 +69,16 @@ description: A test control set
 		});
 
 		it('should handle malformed YAML gracefully', () => {
-			writeFileSync(join(tempDir, 'lula.yaml'), 'invalid: yaml: content: [[[');
+			// Mock console.error to suppress stderr output during test
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+			
+			writeFileSync(join(tempDir, 'lula.yaml'), 'invalid_yaml: {\n  unclosed_bracket: [');
 
 			const result = loadControlSetMetadata(tempDir);
 			expect(result).toEqual({});
+			
+			// Restore console.error
+			consoleSpy.mockRestore();
 		});
 
 		it('should cache metadata and not reload on subsequent calls', () => {

--- a/cli/server/infrastructure/controlHelpers.test.ts
+++ b/cli/server/infrastructure/controlHelpers.test.ts
@@ -71,12 +71,12 @@ description: A test control set
 		it('should handle malformed YAML gracefully', () => {
 			// Mock console.error to suppress stderr output during test
 			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-			
+
 			writeFileSync(join(tempDir, 'lula.yaml'), 'invalid_yaml: {\n  unclosed_bracket: [');
 
 			const result = loadControlSetMetadata(tempDir);
 			expect(result).toEqual({});
-			
+
 			// Restore console.error
 			consoleSpy.mockRestore();
 		});

--- a/cli/server/infrastructure/fileStore.test.ts
+++ b/cli/server/infrastructure/fileStore.test.ts
@@ -216,11 +216,17 @@ control_id_field: id`;
 		});
 
 		it('should handle file read errors gracefully', async () => {
+			// Mock console.error to suppress stderr output during test
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+			
 			const controlsDir = join(tempDir, 'controls', 'INVALID');
 			mkdirSync(controlsDir, { recursive: true });
-			writeFileSync(join(controlsDir, 'INVALID-1.yaml'), 'invalid: yaml: content: [');
+			writeFileSync(join(controlsDir, 'INVALID-1.yaml'), 'invalid_yaml: {\n  unclosed_bracket: [');
 
 			await expect(fileStore.loadControl('INVALID-1')).rejects.toThrow();
+			
+			// Restore console.error
+			consoleSpy.mockRestore();
 		});
 	});
 
@@ -298,13 +304,19 @@ control_id_field: id`;
 		});
 
 		it('should skip controls that fail to load', async () => {
+			// Mock console.error to suppress stderr output during test
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+			
 			const controlsDir = join(tempDir, 'controls', 'INVALID');
 			mkdirSync(controlsDir, { recursive: true });
-			writeFileSync(join(controlsDir, 'INVALID-1.yaml'), 'invalid: yaml: [[[');
+			writeFileSync(join(controlsDir, 'INVALID-1.yaml'), 'invalid_yaml: {\n  unclosed_bracket: [');
 
 			const controls = await fileStore.loadAllControls();
 			expect(controls.length).toBeGreaterThan(0);
 			expect(controls.every((c) => c.id !== 'INVALID-1')).toBe(true);
+			
+			// Restore console.error
+			consoleSpy.mockRestore();
 		});
 	});
 
@@ -433,12 +445,18 @@ control_id_field: id`;
 		});
 
 		it('should handle malformed mapping files gracefully', async () => {
+			// Mock console.error to suppress stderr output during test
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+			
 			const mappingsDir = join(tempDir, 'mappings', 'INVALID');
 			mkdirSync(mappingsDir, { recursive: true });
-			writeFileSync(join(mappingsDir, 'INVALID-1-mappings.yaml'), 'invalid: yaml: [[[');
+			writeFileSync(join(mappingsDir, 'INVALID-1-mappings.yaml'), 'invalid_yaml: {\n  unclosed_bracket: [');
 
 			const mappings = await fileStore.loadMappings();
 			expect(mappings.length).toBeGreaterThan(0);
+			
+			// Restore console.error
+			consoleSpy.mockRestore();
 		});
 	});
 
@@ -528,12 +546,18 @@ control_id_field: id`;
 		});
 
 		it('should clear and refresh the control metadata cache', () => {
+			// Mock console.error to suppress stderr output during test
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+			
 			expect(fileStore.getControlMetadata('AC-1')).toBeDefined();
 
 			fileStore.clearCache();
 
 			const metadata = fileStore.getControlMetadata('AC-1');
 			expect(metadata).toBeDefined();
+			
+			// Restore console.error
+			consoleSpy.mockRestore();
 		});
 	});
 });

--- a/cli/server/infrastructure/fileStore.test.ts
+++ b/cli/server/infrastructure/fileStore.test.ts
@@ -218,13 +218,13 @@ control_id_field: id`;
 		it('should handle file read errors gracefully', async () => {
 			// Mock console.error to suppress stderr output during test
 			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-			
+
 			const controlsDir = join(tempDir, 'controls', 'INVALID');
 			mkdirSync(controlsDir, { recursive: true });
 			writeFileSync(join(controlsDir, 'INVALID-1.yaml'), 'invalid_yaml: {\n  unclosed_bracket: [');
 
 			await expect(fileStore.loadControl('INVALID-1')).rejects.toThrow();
-			
+
 			// Restore console.error
 			consoleSpy.mockRestore();
 		});
@@ -306,7 +306,7 @@ control_id_field: id`;
 		it('should skip controls that fail to load', async () => {
 			// Mock console.error to suppress stderr output during test
 			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-			
+
 			const controlsDir = join(tempDir, 'controls', 'INVALID');
 			mkdirSync(controlsDir, { recursive: true });
 			writeFileSync(join(controlsDir, 'INVALID-1.yaml'), 'invalid_yaml: {\n  unclosed_bracket: [');
@@ -314,7 +314,7 @@ control_id_field: id`;
 			const controls = await fileStore.loadAllControls();
 			expect(controls.length).toBeGreaterThan(0);
 			expect(controls.every((c) => c.id !== 'INVALID-1')).toBe(true);
-			
+
 			// Restore console.error
 			consoleSpy.mockRestore();
 		});
@@ -447,14 +447,17 @@ control_id_field: id`;
 		it('should handle malformed mapping files gracefully', async () => {
 			// Mock console.error to suppress stderr output during test
 			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-			
+
 			const mappingsDir = join(tempDir, 'mappings', 'INVALID');
 			mkdirSync(mappingsDir, { recursive: true });
-			writeFileSync(join(mappingsDir, 'INVALID-1-mappings.yaml'), 'invalid_yaml: {\n  unclosed_bracket: [');
+			writeFileSync(
+				join(mappingsDir, 'INVALID-1-mappings.yaml'),
+				'invalid_yaml: {\n  unclosed_bracket: ['
+			);
 
 			const mappings = await fileStore.loadMappings();
 			expect(mappings.length).toBeGreaterThan(0);
-			
+
 			// Restore console.error
 			consoleSpy.mockRestore();
 		});
@@ -548,14 +551,14 @@ control_id_field: id`;
 		it('should clear and refresh the control metadata cache', () => {
 			// Mock console.error to suppress stderr output during test
 			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-			
+
 			expect(fileStore.getControlMetadata('AC-1')).toBeDefined();
 
 			fileStore.clearCache();
 
 			const metadata = fileStore.getControlMetadata('AC-1');
 			expect(metadata).toBeDefined();
-			
+
 			// Restore console.error
 			consoleSpy.mockRestore();
 		});

--- a/cli/server/infrastructure/yamlDiff.test.ts
+++ b/cli/server/infrastructure/yamlDiff.test.ts
@@ -242,7 +242,7 @@ category: security
 		it('should handle malformed YAML gracefully', () => {
 			// Mock console.error to suppress stderr output during test
 			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-			
+
 			const yaml1 = 'valid: yaml';
 			const yaml2 = 'invalid_yaml: {\n  unclosed_bracket: [';
 
@@ -250,7 +250,7 @@ category: security
 
 			expect(result.hasChanges).toBe(false);
 			expect(result.summary).toBe('Error parsing YAML content');
-			
+
 			// Restore console.error
 			consoleSpy.mockRestore();
 		});

--- a/cli/server/infrastructure/yamlDiff.test.ts
+++ b/cli/server/infrastructure/yamlDiff.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Lula Authors
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createYamlDiff } from './yamlDiff';
 
 describe('yamlDiff', () => {
@@ -240,13 +240,19 @@ category: security
 		});
 
 		it('should handle malformed YAML gracefully', () => {
+			// Mock console.error to suppress stderr output during test
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+			
 			const yaml1 = 'valid: yaml';
-			const yaml2 = 'invalid: yaml: content: [[[';
+			const yaml2 = 'invalid_yaml: {\n  unclosed_bracket: [';
 
 			const result = createYamlDiff(yaml1, yaml2);
 
 			expect(result.hasChanges).toBe(false);
 			expect(result.summary).toBe('Error parsing YAML content');
+			
+			// Restore console.error
+			consoleSpy.mockRestore();
 		});
 
 		it('should generate meaningful summaries', () => {


### PR DESCRIPTION
## Description

mock stderr bc the test output was messy

```bash
Failed to parse lula.yaml at /Users/cmwylie19/lula/test-temp/controlhelpers-1757621663375/lula.yaml: YAMLException: unexpected end of the stream within a flow collection (3:1)

 1 | invalid_yaml: {
 2 |   unclosed_bracket: [
 3 | 
-----^
    at generateError (file:///Users/cmwylie19/lula/node_modules/.pnpm/js-yaml@4.1.0/node_modules/js-yaml/dist/js-yaml.mjs:1273:10)
    at throwError (file:///Users/cmwylie19/lula/node_modules/.pnpm/js-yaml@4.1.0/node_modules/js-yaml/dist/js-yaml.mjs:1277:9)
    at readFlowCollection (file:///Users/cmwylie19/lula/node_modules/.pnpm/js-yaml@4.1.0/node_modules/js-yaml/dist/js-yaml.mjs:1905:3)
    at composeNode (file:///Users/cmwylie19/lula/node_modules/.pnpm/js-yaml@4.1.0/node_modules/js-yaml/dist/js-yaml.mjs:2532:11)
    at readFlowCollection (file:///Users/cmwylie19/lula/node_modules/.pnpm/js-yaml@4.1.0/node_modules/js-yaml/dist/js-yaml.mjs:1881:7)
    at composeNode (file:///Users/cmwylie19/lula/node_modules/.pnpm/js-yaml@4.1.0/node_modules/js-yaml/dist/js-yaml.mjs:2532:11)
    at readBlockMapping (file:///Users/cmwylie19/lula/node_modules/.pnpm/js-yaml@4.1.0/node_modules/js-yaml/dist/js-yaml.mjs:2254:11)
    at composeNode (file:///Users/cmwylie19/lula/node_modules/.pnpm/js-yaml@4.1.0/node_modules/js-yaml/dist/js-yaml.mjs:2531:12)
    at readDocument (file:///Users/cmwylie19/lula/node_modules/.pnpm/js-yaml@4.1.0/node_modules/js-yaml/dist/js-yaml.mjs:2715:3)
    at loadDocuments (file:///Users/cmwylie19/lula/node_modules/.pnpm/js-yaml@4.1.0/node_modules/js-yaml/dist/js-yaml.mjs:2778:5) {
  reason: 'unexpected end of the stream within a flow collection',
  mark: {
    name: null,
    buffer: 'invalid_yaml: {\n  unclosed_bracket: [\n',
    position: 38,
    line: 2,
    column: 0,
    snippet: ' 1 | invalid_yaml: {\n 2 |   unclosed_bracket: [\n 3 | \n-----^'
  }
  ```

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
