### PR TITLE
fix: only leave post if there are changed blocks

### DIFF
--- a/cli/commands/crawl.ts
+++ b/cli/commands/crawl.ts
@@ -198,6 +198,7 @@ export function getChangedBlocks(
 
 	return changed;
 }
+let leavePost = false;
 /**
  * Defines the "crawl" command for the CLI.
  *
@@ -239,6 +240,7 @@ export function crawlCommand(): Command {
 					const changedBlocks = getChangedBlocks(oldText, newText);
 
 					for (const block of changedBlocks) {
+						leavePost = true;
 						commentBody += `\n\n---\n| File | Lines Changed |\n` + `| ---- | ------------- |\n`;
 						const newBlockText = newText
 							.split('\n')
@@ -252,7 +254,7 @@ export function crawlCommand(): Command {
 					console.error(`Error processing ${file.filename}: ${err}`);
 				}
 			}
-			if (files.length > 0) {
+			if (leavePost) {
 				await postFinding({
 					octokit,
 					postMode: opts.postMode,

--- a/cli/commands/crawl.ts
+++ b/cli/commands/crawl.ts
@@ -198,7 +198,7 @@ export function getChangedBlocks(
 
 	return changed;
 }
-let leavePost = false;
+
 /**
  * Defines the "crawl" command for the CLI.
  *
@@ -214,6 +214,7 @@ export function crawlCommand(): Command {
 				.default('review')
 		)
 		.action(async (opts) => {
+			let leavePost = false;
 			const { owner, repo, pull_number } = getPRContext();
 			console.log(`Analyzing PR #${pull_number} in ${owner}/${repo} for compliance changes...`);
 			const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });


### PR DESCRIPTION
## Description

This UDS Core [PR](https://github.com/defenseunicorns/uds-core/pull/1927#pullrequestreview-3234794260) had a post when it should not have. We should only leave a post if there are changed blocks.

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
