### PR TITLE
fix: id mapping

### DIFF
--- a/cli/server/infrastructure/fileStore.test.ts
+++ b/cli/server/infrastructure/fileStore.test.ts
@@ -27,7 +27,7 @@ describe('FileStore', () => {
 
 		const lulaConfig = `id: test-control-set
 name: Test Control Set
-control_id_field: id`;
+control_id_field: ap-acronym`;
 		writeFileSync(join(tempDir, 'lula.yaml'), lulaConfig);
 
 		fileStore = new FileStore({ baseDir: tempDir });
@@ -182,7 +182,7 @@ control_id_field: id`;
 		beforeEach(async () => {
 			// Set up test control
 			const control: Partial<Control> = {
-				id: 'AC-1',
+				'ap-acronym': 'AC-1',
 				title: 'Access Control Policy',
 				description: 'Test control'
 			};
@@ -208,7 +208,7 @@ control_id_field: id`;
 			mkdirSync(controlsDir, { recursive: true });
 			writeFileSync(
 				join(controlsDir, 'TEST-1.yaml'),
-				'title: Test Control\ndescription: No ID field'
+				'title: Test Control\ndescription: No ID field\nap-acronym: TEST-1'
 			);
 
 			const control = await fileStore.loadControl('TEST-1');
@@ -265,9 +265,9 @@ control_id_field: id`;
 		beforeEach(async () => {
 			// Set up multiple test controls
 			const controls: Partial<Control>[] = [
-				{ id: 'AC-1', title: 'Access Control Policy 1' },
-				{ id: 'AC-2', title: 'Access Control Policy 2' },
-				{ id: 'AU-1', title: 'Audit Policy 1' }
+				{ 'ap-acronym': 'AC-1', title: 'Access Control Policy 1' },
+				{ 'ap-acronym': 'AC-2', title: 'Access Control Policy 2' },
+				{ 'ap-acronym': 'AU-1', title: 'Audit Policy 1' }
 			];
 
 			for (const control of controls) {
@@ -296,7 +296,7 @@ control_id_field: id`;
 		it('should handle flat structure (atomic controls)', async () => {
 			const controlsDir = join(tempDir, 'controls');
 			mkdirSync(controlsDir, { recursive: true });
-			writeFileSync(join(controlsDir, 'FLAT-1.yaml'), 'id: FLAT-1\ntitle: Flat Control');
+			writeFileSync(join(controlsDir, 'FLAT-1.yaml'), 'ap-acronym: FLAT-1\ntitle: Flat Control');
 
 			const controls = await fileStore.loadAllControls();
 			const flatControl = controls.find((c) => c.id === 'FLAT-1');

--- a/cli/server/infrastructure/fileStore.test.ts
+++ b/cli/server/infrastructure/fileStore.test.ts
@@ -4,8 +4,8 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { FileStore } from './fileStore';
 import type { Control, Mapping } from '../types';
+import { FileStore } from './fileStore';
 
 vi.mock('./controlHelpers', () => ({
 	getControlId: vi.fn((control: Partial<Control>) => {
@@ -208,7 +208,7 @@ control_id_field: ap-acronym`;
 			mkdirSync(controlsDir, { recursive: true });
 			writeFileSync(
 				join(controlsDir, 'TEST-1.yaml'),
-				'title: Test Control\ndescription: No ID field\nap-acronym: TEST-1'
+				'title: Test Control\ndescription: No ID field'
 			);
 
 			const control = await fileStore.loadControl('TEST-1');

--- a/cli/server/infrastructure/fileStore.test.ts
+++ b/cli/server/infrastructure/fileStore.test.ts
@@ -27,7 +27,7 @@ describe('FileStore', () => {
 
 		const lulaConfig = `id: test-control-set
 name: Test Control Set
-control_id_field: ap-acronym`;
+control_id_field: id`;
 		writeFileSync(join(tempDir, 'lula.yaml'), lulaConfig);
 
 		fileStore = new FileStore({ baseDir: tempDir });
@@ -182,7 +182,7 @@ control_id_field: ap-acronym`;
 		beforeEach(async () => {
 			// Set up test control
 			const control: Partial<Control> = {
-				'ap-acronym': 'AC-1',
+				id: 'AC-1',
 				title: 'Access Control Policy',
 				description: 'Test control'
 			};
@@ -265,9 +265,9 @@ control_id_field: ap-acronym`;
 		beforeEach(async () => {
 			// Set up multiple test controls
 			const controls: Partial<Control>[] = [
-				{ 'ap-acronym': 'AC-1', title: 'Access Control Policy 1' },
-				{ 'ap-acronym': 'AC-2', title: 'Access Control Policy 2' },
-				{ 'ap-acronym': 'AU-1', title: 'Audit Policy 1' }
+				{ id: 'AC-1', title: 'Access Control Policy 1' },
+				{ id: 'AC-2', title: 'Access Control Policy 2' },
+				{ id: 'AU-1', title: 'Audit Policy 1' }
 			];
 
 			for (const control of controls) {
@@ -296,7 +296,7 @@ control_id_field: ap-acronym`;
 		it('should handle flat structure (atomic controls)', async () => {
 			const controlsDir = join(tempDir, 'controls');
 			mkdirSync(controlsDir, { recursive: true });
-			writeFileSync(join(controlsDir, 'FLAT-1.yaml'), 'ap-acronym: FLAT-1\ntitle: Flat Control');
+			writeFileSync(join(controlsDir, 'FLAT-1.yaml'), 'id: FLAT-1\ntitle: Flat Control');
 
 			const controls = await fileStore.loadAllControls();
 			const flatControl = controls.find((c) => c.id === 'FLAT-1');

--- a/cli/server/infrastructure/fileStore.ts
+++ b/cli/server/infrastructure/fileStore.ts
@@ -142,9 +142,7 @@ export class FileStore {
 					// Ensure the control has an 'id' field
 					// Always use the original control ID format (with dots, not underscores)
 					if (!parsed.id) {
-						// If the filename has underscores, convert back to dots
-						// AC-10_3 -> AC-10.3, but leave AC-10 as-is
-						parsed.id = controlId.replace(/_(\d)/g, '.$1');
+						parsed.id = getControlId(parsed, this.baseDir);
 					}
 					return parsed as Control;
 				} catch (error) {
@@ -174,9 +172,7 @@ export class FileStore {
 					// Ensure the control has an 'id' field
 					// Always use the original control ID format (with dots, not underscores)
 					if (!parsed.id) {
-						// If the filename has underscores, convert back to dots
-						// AC-10_3 -> AC-10.3, but leave AC-10 as-is
-						parsed.id = controlId.replace(/_(\d)/g, '.$1');
+						parsed.id = getControlId(parsed, this.baseDir);
 					}
 					return parsed as Control;
 				} catch (error) {

--- a/cli/server/infrastructure/fileStore.ts
+++ b/cli/server/infrastructure/fileStore.ts
@@ -142,7 +142,12 @@ export class FileStore {
 					// Ensure the control has an 'id' field
 					// Always use the original control ID format (with dots, not underscores)
 					if (!parsed.id) {
-						parsed.id = getControlId(parsed, this.baseDir);
+						try {
+							parsed.id = getControlId(parsed, this.baseDir);
+						} catch (error) {
+							// Fallback to the controlId parameter if getControlId fails
+							parsed.id = controlId;
+						}
 					}
 					return parsed as Control;
 				} catch (error) {
@@ -172,7 +177,12 @@ export class FileStore {
 					// Ensure the control has an 'id' field
 					// Always use the original control ID format (with dots, not underscores)
 					if (!parsed.id) {
-						parsed.id = getControlId(parsed, this.baseDir);
+						try {
+							parsed.id = getControlId(parsed, this.baseDir);
+						} catch (error) {
+							// Fallback to the controlId parameter if getControlId fails
+							parsed.id = controlId;
+						}
 					}
 					return parsed as Control;
 				} catch (error) {


### PR DESCRIPTION
## Description

Uses the getControlId function that is used in other locations rather than trying to reverse parse from the `_` filename/ID.