### PR TITLE
fix: export and import mappings in csv

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
-	"*.ts": ["prettier --config .prettierrc --write", "eslint --config eslint.config.js --fix --ignore integration/test-files/**"],
+	"*.ts": ["prettier --config .prettierrc --write", "eslint --config eslint.config.js --fix"],
 	"*.test.ts": ["eslint --config eslint.config.js"],
 	"integration/**/*.ts": ["eslint --config eslint.config.js"],
 	"*.mjs": ["prettier --config .prettierrc --write"],

--- a/cli/server/spreadsheetRoutes.ts
+++ b/cli/server/spreadsheetRoutes.ts
@@ -18,12 +18,6 @@ interface SpreadsheetRow {
 	[key: string]: any;
 }
 
-interface MappingData {
-	control_id: string;
-	justification: string;
-	uuid: string;
-}
-
 const router: express.Router = express.Router();
 const upload = multer({
 	storage: multer.memoryStorage(),
@@ -511,13 +505,6 @@ router.post('/import-spreadsheet', upload.single('file'), async (req, res) => {
 				// Filter control to only include fields that are in the field schema (not excluded)
 				const filteredControl: SpreadsheetRow = {};
 
-				// Prepare mapping data with empty justification
-				const mappingData: MappingData = {
-					control_id: controlIdStr,
-					justification: '',
-					uuid: crypto.randomUUID()
-				};
-
 				// Collect justification content from all specified fields
 				const justificationContents: string[] = [];
 
@@ -567,15 +554,6 @@ router.post('/import-spreadsheet', upload.single('file'), async (req, res) => {
 						uuid: mapping.uuid || crypto.randomUUID()
 					}));
 					writeFileSync(mappingFilePath, yaml.dump(mappingArray));
-				} else if (justificationContents.length > 0) {
-					// Combine all justification contents with line breaks
-					mappingData.justification = justificationContents.join('\n\n');
-					// Write mapping file if it has justification content
-					if (mappingData.justification && mappingData.justification.trim() !== '') {
-						// Format as an array with a single mapping entry
-						const mappingArray = [mappingData];
-						writeFileSync(mappingFilePath, yaml.dump(mappingArray));
-					}
 				}
 			});
 		});

--- a/cli/server/spreadsheetRoutes.ts
+++ b/cli/server/spreadsheetRoutes.ts
@@ -571,7 +571,7 @@ router.post('/import-spreadsheet', upload.single('file'), async (req, res) => {
 });
 
 // Helper function to parse mappings from CSV format
-function parseMappingsFromCSV(mappingsString: string): any[] {
+export function parseMappingsFromCSV(mappingsString: string): any[] {
 	if (!mappingsString || mappingsString.trim() === '') {
 		return [];
 	}

--- a/cli/server/spreadsheetRoutes.ts
+++ b/cli/server/spreadsheetRoutes.ts
@@ -790,7 +790,7 @@ router.get('/export-controls', async (req, res) => {
 				mappings_count: controlMappings.length,
 				mappings: controlMappings.map((m) => ({
 					uuid: m.uuid,
-					status: m.status || 'undefined',
+					status: m.status === undefined ? undefined : m.status,
 					description: m.justification || '',
 					source_entries: m.source_entries || []
 				}))

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,7 +38,8 @@ export default ts.config(
 			'mappings/**',
 			'build/**',
 			'.svelte-kit/**',
-			'dist/**'
+			'dist/**',
+			'integration/test-files/**'
 		]
 	},
 	{


### PR DESCRIPTION
## Description

Currently it is not possible to export the csv file with the mappings that were created in the UI. This means that you also cannot import them.

The PR adds the ability to export controls through the CSV and import controls from the CSV so you can distribute work through the CSV

## Related Issue

Fixes #175 
Fixes #165 

<!-- or -->

Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
