### PR TITLE
chore: reduce complexity in import-spreadsheet and tests

### DIFF
--- a/cli/server/spreadsheetRoutes.test.ts
+++ b/cli/server/spreadsheetRoutes.test.ts
@@ -2,19 +2,46 @@
 // SPDX-FileCopyrightText: 2025-Present The Lula2 Authors
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { scanControlSets } from './spreadsheetRoutes';
+import {
+	scanControlSets,
+	processImportParameters,
+	parseUploadedFile,
+	processSpreadsheetData,
+	buildFieldSchema,
+	createOutputStructure,
+	applyNamingConvention,
+	toCamelCase,
+	toSnakeCase,
+	toKebabCase,
+	detectValueType,
+	parseCSV,
+	extractFamilyFromControlId
+} from './spreadsheetRoutes';
+import type { ImportParameters } from './spreadsheetRoutes';
 import { getServerState } from './serverState';
-import { readFileSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { glob } from 'glob';
 import * as yaml from 'js-yaml';
+import ExcelJS from 'exceljs';
 
 vi.mock('fs');
 vi.mock('glob');
 vi.mock('js-yaml');
 vi.mock('./serverState');
+vi.mock('exceljs');
+vi.mock('crypto', () => ({
+	default: {
+		randomUUID: vi.fn(() => 'test-uuid-123')
+	}
+}));
+
 const mockReadFileSync = vi.mocked(readFileSync);
+const mockWriteFileSync = vi.mocked(writeFileSync);
+const mockExistsSync = vi.mocked(existsSync);
+const mockMkdirSync = vi.mocked(mkdirSync);
 const mockGlob = vi.mocked(glob);
 const mockYamlLoad = vi.mocked(yaml.load);
+const mockYamlDump = vi.mocked(yaml.dump);
 const mockGetServerState = vi.mocked(getServerState);
 
 describe('spreadsheetRoutes', () => {
@@ -361,6 +388,926 @@ describe('spreadsheetRoutes', () => {
 			});
 
 			expect(() => getServerState()).toThrow('Server state not initialized');
+		});
+	});
+
+	describe('processImportParameters', () => {
+		it('should extract basic parameters with defaults', () => {
+			const reqBody = {
+				controlIdField: 'ID',
+				startRow: '2',
+				controlSetName: 'Test Control Set',
+				controlSetDescription: 'Test Description'
+			};
+
+			const result = processImportParameters(reqBody);
+
+			expect(result).toEqual({
+				controlIdField: 'ID',
+				startRow: '2',
+				controlSetName: 'Test Control Set',
+				controlSetDescription: 'Test Description',
+				justificationFields: [],
+				namingConvention: 'kebab-case',
+				skipEmpty: true,
+				skipEmptyRows: true,
+				frontendFieldSchema: null
+			});
+		});
+
+		it('should use default values when parameters are missing', () => {
+			const reqBody = {};
+
+			const result = processImportParameters(reqBody);
+
+			expect(result).toEqual({
+				controlIdField: 'Control ID',
+				startRow: '1',
+				controlSetName: 'Imported Control Set',
+				controlSetDescription: 'Imported from spreadsheet',
+				justificationFields: [],
+				namingConvention: 'kebab-case',
+				skipEmpty: true,
+				skipEmptyRows: true,
+				frontendFieldSchema: null
+			});
+		});
+
+		it('should parse justification fields from JSON', () => {
+			const reqBody = {
+				justificationFields: '["field1", "field2", "field3"]'
+			};
+
+			const result = processImportParameters(reqBody);
+
+			expect(result.justificationFields).toEqual(['field1', 'field2', 'field3']);
+		});
+
+		it('should handle invalid justification fields JSON gracefully', () => {
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+			const reqBody = {
+				justificationFields: 'invalid json'
+			};
+
+			const result = processImportParameters(reqBody);
+
+			expect(result.justificationFields).toEqual([]);
+			expect(consoleSpy).toHaveBeenCalledWith(
+				'Failed to parse justification fields:',
+				expect.any(Error)
+			);
+
+			consoleSpy.mockRestore();
+		});
+
+		it('should parse frontend field schema from JSON', () => {
+			const fieldSchema = [{ fieldName: 'test-field', tab: 'overview', required: true }];
+			const reqBody = {
+				fieldSchema: JSON.stringify(fieldSchema)
+			};
+
+			const result = processImportParameters(reqBody);
+
+			expect(result.frontendFieldSchema).toEqual(fieldSchema);
+		});
+
+		it('should handle invalid field schema JSON gracefully', () => {
+			const reqBody = {
+				fieldSchema: 'invalid json'
+			};
+
+			const result = processImportParameters(reqBody);
+
+			expect(result.frontendFieldSchema).toBeNull();
+		});
+	});
+
+	describe('parseUploadedFile', () => {
+		it('should parse CSV files correctly', async () => {
+			const mockFile = {
+				originalname: 'test.csv',
+				buffer: Buffer.from('Name,Age,City\nJohn,30,NYC\nJane,25,LA')
+			};
+
+			const result = await parseUploadedFile(mockFile);
+
+			expect(result).toEqual([
+				['Name', 'Age', 'City'],
+				['John', '30', 'NYC'],
+				['Jane', '25', 'LA']
+			]);
+		});
+
+		it('should parse Excel files correctly', async () => {
+			const mockWorkbook = {
+				xlsx: {
+					load: vi.fn().mockResolvedValue(undefined)
+				},
+				worksheets: [
+					{
+						eachRow: vi.fn().mockImplementation((options, callback) => {
+							// Mock first row (headers)
+							const row1 = {
+								eachCell: vi.fn().mockImplementation((cellOptions, cellCallback) => {
+									cellCallback({ value: 'Name' }, 1);
+									cellCallback({ value: 'Age' }, 2);
+									cellCallback({ value: 'City' }, 3);
+								})
+							};
+							callback(row1, 1);
+
+							// Mock second row (data)
+							const row2 = {
+								eachCell: vi.fn().mockImplementation((cellOptions, cellCallback) => {
+									cellCallback({ value: 'John' }, 1);
+									cellCallback({ value: 30 }, 2);
+									cellCallback({ value: 'NYC' }, 3);
+								})
+							};
+							callback(row2, 2);
+						})
+					}
+				]
+			};
+
+			vi.mocked(ExcelJS.Workbook).mockImplementation(() => mockWorkbook as any);
+
+			const mockFile = {
+				originalname: 'test.xlsx',
+				buffer: Buffer.from('mock excel data')
+			};
+
+			const result = await parseUploadedFile(mockFile);
+
+			expect(result).toEqual([
+				['Name', 'Age', 'City'],
+				['John', 30, 'NYC']
+			]);
+		});
+
+		it('should throw error when Excel file has no worksheets', async () => {
+			const mockWorkbook = {
+				xlsx: {
+					load: vi.fn().mockResolvedValue(undefined)
+				},
+				worksheets: []
+			};
+
+			vi.mocked(ExcelJS.Workbook).mockImplementation(() => mockWorkbook as any);
+
+			const mockFile = {
+				originalname: 'test.xlsx',
+				buffer: Buffer.from('mock excel data')
+			};
+
+			await expect(parseUploadedFile(mockFile)).rejects.toThrow('No worksheet found in file');
+		});
+	});
+
+	describe('processSpreadsheetData', () => {
+		const mockParams: ImportParameters = {
+			controlIdField: 'Control ID',
+			startRow: '1',
+			controlSetName: 'Test Set',
+			controlSetDescription: 'Test Description',
+			justificationFields: [],
+			namingConvention: 'kebab-case',
+			skipEmpty: true,
+			skipEmptyRows: true,
+			frontendFieldSchema: null
+		};
+
+		it('should process spreadsheet data correctly', () => {
+			const rawData = [
+				['Control ID', 'Title', 'Description'], // headers at index 0
+				['AC-1', 'Access Control Policy', 'Develop access control policy'], // data starts at index 1
+				['AC-2', 'Account Management', 'Manage user accounts']
+			];
+			const headers = rawData[0] as string[];
+			const startRowIndex = 0;
+
+			const result = processSpreadsheetData(rawData, headers, startRowIndex, mockParams);
+
+			expect(result.controls).toHaveLength(2);
+			expect(result.controls[0]).toMatchObject({
+				'control-id': 'AC-1',
+				title: 'Access Control Policy',
+				description: 'Develop access control policy',
+				family: 'AC'
+			});
+			expect(result.controls[1]).toMatchObject({
+				'control-id': 'AC-2',
+				title: 'Account Management',
+				description: 'Manage user accounts',
+				family: 'AC'
+			});
+
+			expect(result.families.has('AC')).toBe(true);
+			expect(result.families.get('AC')).toHaveLength(2);
+		});
+
+		it('should skip rows without control ID', () => {
+			const rawData = [
+				['Control ID', 'Title'],
+				['AC-1', 'Valid Control'],
+				['', 'Invalid - No ID'],
+				[null, 'Invalid - Null ID'],
+				['AC-2', 'Another Valid Control']
+			];
+			const headers = rawData[0] as string[];
+			const startRowIndex = 0;
+
+			const result = processSpreadsheetData(rawData, headers, startRowIndex, mockParams);
+
+			expect(result.controls).toHaveLength(2);
+			expect(result.controls[0]['control-id']).toBe('AC-1');
+			expect(result.controls[1]['control-id']).toBe('AC-2');
+		});
+
+		it('should handle empty rows correctly when skipEmptyRows is true', () => {
+			const rawData = [
+				['Control ID', 'Title'],
+				['AC-1', 'Valid Control'],
+				[], // Empty row
+				['AC-2', 'Another Valid Control']
+			];
+			const headers = rawData[0] as string[];
+			const startRowIndex = 0;
+
+			const result = processSpreadsheetData(rawData, headers, startRowIndex, mockParams);
+
+			expect(result.controls).toHaveLength(2);
+		});
+
+		it('should collect field metadata correctly', () => {
+			const rawData = [
+				['Control ID', 'Title', 'Priority'],
+				['AC-1', 'Short Title', 'High'],
+				['AC-2', 'This is a much longer title that exceeds normal length', 'Low'],
+				['AC-3', 'Medium Title', 'Medium']
+			];
+			const headers = rawData[0] as string[];
+			const startRowIndex = 0;
+
+			const result = processSpreadsheetData(rawData, headers, startRowIndex, mockParams);
+
+			const titleMetadata = result.fieldMetadata.get('title');
+			expect(titleMetadata).toBeDefined();
+			expect(titleMetadata!.maxLength).toBeGreaterThan(50); // Should capture the long title length
+			expect(titleMetadata!.uniqueValues.size).toBe(3);
+			expect(titleMetadata!.totalCount).toBe(3);
+		});
+
+		it('should detect different value types correctly', () => {
+			const rawData = [
+				['Control ID', 'Number Field', 'Boolean Field', 'Date Field'],
+				['AC-1', '123', 'true', '2023-01-01'],
+				['AC-2', '456.78', 'false', '12/31/2023'],
+				['AC-3', '0', 'yes', '01/15/2024']
+			];
+			const headers = rawData[0] as string[];
+			const startRowIndex = 0;
+
+			const result = processSpreadsheetData(rawData, headers, startRowIndex, mockParams);
+
+			const numberMetadata = result.fieldMetadata.get('number-field');
+			const booleanMetadata = result.fieldMetadata.get('boolean-field');
+			const dateMetadata = result.fieldMetadata.get('date-field');
+
+			expect(numberMetadata!.type).toBe('number');
+			expect(booleanMetadata!.type).toBe('boolean');
+			expect(dateMetadata!.type).toBe('date');
+		});
+	});
+
+	describe('buildFieldSchema', () => {
+		it('should build field schema correctly with family field', () => {
+			const mockFieldMetadata = new Map();
+			mockFieldMetadata.set('control-id', {
+				originalName: 'Control ID',
+				type: 'string',
+				maxLength: 10,
+				hasMultipleLines: false,
+				uniqueValues: new Set(['AC-1', 'AC-2']),
+				emptyCount: 0,
+				totalCount: 2,
+				examples: ['AC-1', 'AC-2']
+			});
+
+			const mockControls = [
+				{ 'control-id': 'AC-1', family: 'AC' },
+				{ 'control-id': 'AC-2', family: 'AC' }
+			];
+
+			const mockFamilies = new Map();
+			mockFamilies.set('AC', mockControls);
+
+			const mockParams: ImportParameters = {
+				controlIdField: 'Control ID',
+				startRow: '1',
+				controlSetName: 'Test Set',
+				controlSetDescription: 'Test Description',
+				justificationFields: [],
+				namingConvention: 'kebab-case',
+				skipEmpty: true,
+				skipEmptyRows: true,
+				frontendFieldSchema: null
+			};
+
+			const result = buildFieldSchema(mockFieldMetadata, mockControls, mockParams, mockFamilies);
+
+			expect(result.fields.family).toBeDefined();
+			expect(result.fields.family).toMatchObject({
+				type: 'string',
+				ui_type: 'select',
+				usage_count: 2,
+				usage_percentage: 100,
+				required: true,
+				category: 'core'
+			});
+
+			expect(result.fields['control-id']).toBeDefined();
+			expect(result.fields['control-id']).toMatchObject({
+				type: 'string',
+				required: true,
+				editable: false,
+				category: 'core'
+			});
+		});
+
+		it('should handle frontend field schema configuration', () => {
+			const mockFieldMetadata = new Map();
+			mockFieldMetadata.set('custom-field', {
+				originalName: 'Custom Field',
+				type: 'string',
+				maxLength: 20,
+				hasMultipleLines: false,
+				uniqueValues: new Set(['value1', 'value2']),
+				emptyCount: 0,
+				totalCount: 2,
+				examples: ['value1']
+			});
+
+			const mockControls = [{ 'custom-field': 'value1' }];
+			const mockFamilies = new Map();
+
+			const mockParams: ImportParameters = {
+				controlIdField: 'Control ID',
+				startRow: '1',
+				controlSetName: 'Test Set',
+				controlSetDescription: 'Test Description',
+				justificationFields: [],
+				namingConvention: 'kebab-case',
+				skipEmpty: true,
+				skipEmptyRows: true,
+				frontendFieldSchema: [
+					{
+						fieldName: 'custom-field',
+						tab: 'custom',
+						category: 'custom',
+						required: false,
+						displayOrder: 5
+					}
+				]
+			};
+
+			const result = buildFieldSchema(mockFieldMetadata, mockControls, mockParams, mockFamilies);
+
+			expect(result.fields['custom-field']).toMatchObject({
+				category: 'custom',
+				tab: 'custom',
+				display_order: 5,
+				required: false
+			});
+		});
+
+		it('should determine appropriate UI types based on metadata', () => {
+			const mockFieldMetadata = new Map();
+
+			// Textarea field (long text)
+			mockFieldMetadata.set('long-description', {
+				originalName: 'Long Description',
+				type: 'string',
+				maxLength: 1000,
+				hasMultipleLines: true,
+				uniqueValues: new Set(['long text']),
+				emptyCount: 0,
+				totalCount: 1,
+				examples: ['long text']
+			});
+
+			// Select field (few unique values)
+			mockFieldMetadata.set('status', {
+				originalName: 'Status',
+				type: 'string',
+				maxLength: 10,
+				hasMultipleLines: false,
+				uniqueValues: new Set(['active', 'inactive']),
+				emptyCount: 0,
+				totalCount: 10,
+				examples: ['active']
+			});
+
+			const mockControls = [{}];
+			const mockFamilies = new Map();
+			const mockParams: ImportParameters = {
+				controlIdField: 'Control ID',
+				startRow: '1',
+				controlSetName: 'Test Set',
+				controlSetDescription: 'Test Description',
+				justificationFields: [],
+				namingConvention: 'kebab-case',
+				skipEmpty: true,
+				skipEmptyRows: true,
+				frontendFieldSchema: null
+			};
+
+			const result = buildFieldSchema(mockFieldMetadata, mockControls, mockParams, mockFamilies);
+
+			expect(result.fields['long-description']).toMatchObject({
+				ui_type: 'textarea'
+			});
+
+			expect(result.fields['status']).toMatchObject({
+				ui_type: 'select',
+				options: ['active', 'inactive']
+			});
+		});
+	});
+
+	describe('createOutputStructure', () => {
+		beforeEach(() => {
+			mockExistsSync.mockReturnValue(false);
+			mockYamlDump.mockReturnValue('mocked yaml content');
+		});
+
+		it('should create directory structure and files correctly', async () => {
+			const mockProcessedData = {
+				controls: [{ 'control-id': 'AC-1', title: 'Test Control', family: 'AC' }],
+				families: new Map([['AC', [{ 'control-id': 'AC-1', title: 'Test Control', family: 'AC' }]]])
+			};
+
+			const mockFieldSchema = {
+				fields: {
+					'control-id': { type: 'string' },
+					title: { type: 'string' }
+				}
+			};
+
+			const mockParams: ImportParameters = {
+				controlIdField: 'Control ID',
+				startRow: '1',
+				controlSetName: 'Test Control Set',
+				controlSetDescription: 'Test Description',
+				justificationFields: [],
+				namingConvention: 'kebab-case',
+				skipEmpty: true,
+				skipEmptyRows: true,
+				frontendFieldSchema: null
+			};
+
+			mockGetServerState.mockReturnValue({
+				CONTROL_SET_DIR: '/test/control-sets',
+				currentSubdir: '.',
+				fileStore: {} as any,
+				gitHistory: {} as any,
+				controlsCache: new Map(),
+				mappingsCache: new Map(),
+				controlsByFamily: new Map(),
+				mappingsByFamily: new Map(),
+				mappingsByControl: new Map()
+			});
+
+			const result = await createOutputStructure(mockProcessedData, mockFieldSchema, mockParams);
+
+			expect(result.folderName).toBe('test-control-set');
+			expect(mockMkdirSync).toHaveBeenCalledWith('/test/control-sets/test-control-set', {
+				recursive: true
+			});
+			expect(mockMkdirSync).toHaveBeenCalledWith(
+				'/test/control-sets/test-control-set/controls/AC',
+				{ recursive: true }
+			);
+			expect(mockWriteFileSync).toHaveBeenCalledWith(
+				'/test/control-sets/test-control-set/lula.yaml',
+				'mocked yaml content'
+			);
+		});
+
+		it('should handle justification fields correctly', async () => {
+			const mockProcessedData = {
+				controls: [
+					{
+						'control-id': 'AC-1',
+						title: 'Test Control',
+						family: 'AC',
+						'justification-field': 'This is justification text'
+					}
+				],
+				families: new Map([
+					[
+						'AC',
+						[
+							{
+								'control-id': 'AC-1',
+								title: 'Test Control',
+								family: 'AC',
+								'justification-field': 'This is justification text'
+							}
+						]
+					]
+				])
+			};
+
+			const mockFieldSchema = {
+				fields: {
+					'control-id': { type: 'string' },
+					title: { type: 'string' },
+					'justification-field': { type: 'string' }
+				}
+			};
+
+			const mockParams: ImportParameters = {
+				controlIdField: 'Control ID',
+				startRow: '1',
+				controlSetName: 'Test Control Set',
+				controlSetDescription: 'Test Description',
+				justificationFields: ['justification-field'],
+				namingConvention: 'kebab-case',
+				skipEmpty: true,
+				skipEmptyRows: true,
+				frontendFieldSchema: null
+			};
+
+			mockGetServerState.mockReturnValue({
+				CONTROL_SET_DIR: '/test/control-sets',
+				currentSubdir: '.',
+				fileStore: {} as any,
+				gitHistory: {} as any,
+				controlsCache: new Map(),
+				mappingsCache: new Map(),
+				controlsByFamily: new Map(),
+				mappingsByFamily: new Map(),
+				mappingsByControl: new Map()
+			});
+
+			await createOutputStructure(mockProcessedData, mockFieldSchema, mockParams);
+
+			// Should create a mapping file with justification
+			expect(mockWriteFileSync).toHaveBeenCalledWith(
+				'/test/control-sets/test-control-set/mappings/AC/AC-1-mappings.yaml',
+				'mocked yaml content'
+			);
+		});
+
+		it('should skip directory creation if it already exists', async () => {
+			mockExistsSync.mockReturnValue(true); // Directory already exists
+
+			const mockProcessedData = {
+				controls: [],
+				families: new Map()
+			};
+
+			const mockFieldSchema = { fields: {} };
+
+			const mockParams: ImportParameters = {
+				controlIdField: 'Control ID',
+				startRow: '1',
+				controlSetName: 'Test Control Set',
+				controlSetDescription: 'Test Description',
+				justificationFields: [],
+				namingConvention: 'kebab-case',
+				skipEmpty: true,
+				skipEmptyRows: true,
+				frontendFieldSchema: null
+			};
+
+			mockGetServerState.mockReturnValue({
+				CONTROL_SET_DIR: '/test/control-sets',
+				currentSubdir: '.',
+				fileStore: {} as any,
+				gitHistory: {} as any,
+				controlsCache: new Map(),
+				mappingsCache: new Map(),
+				controlsByFamily: new Map(),
+				mappingsByFamily: new Map(),
+				mappingsByControl: new Map()
+			});
+
+			await createOutputStructure(mockProcessedData, mockFieldSchema, mockParams);
+
+			expect(mockMkdirSync).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('applyNamingConvention', () => {
+		it('should return empty string for empty input', () => {
+			expect(applyNamingConvention('', 'kebab-case')).toBe('');
+			expect(applyNamingConvention(null as any, 'kebab-case')).toBe(null);
+			expect(applyNamingConvention(undefined as any, 'kebab-case')).toBe(undefined);
+		});
+
+		it('should apply camelCase convention', () => {
+			expect(applyNamingConvention('control id', 'camelCase')).toBe('controlId');
+			expect(applyNamingConvention('Control ID Field', 'camelCase')).toBe('controlIDField');
+			expect(applyNamingConvention('UPPER CASE', 'camelCase')).toBe('uPPERCASE');
+		});
+
+		it('should apply snake_case convention', () => {
+			expect(applyNamingConvention('Control ID', 'snake_case')).toBe('control_id');
+			expect(applyNamingConvention('Field Name', 'snake_case')).toBe('field_name');
+			expect(applyNamingConvention('Multi Word Field', 'snake_case')).toBe('multi_word_field');
+		});
+
+		it('should apply kebab-case convention', () => {
+			expect(applyNamingConvention('Control ID', 'kebab-case')).toBe('control-id');
+			expect(applyNamingConvention('Field Name', 'kebab-case')).toBe('field-name');
+			expect(applyNamingConvention('Multi Word Field', 'kebab-case')).toBe('multi-word-field');
+		});
+
+		it('should apply lowercase convention', () => {
+			expect(applyNamingConvention('Control ID', 'lowercase')).toBe('controlid');
+			expect(applyNamingConvention('Field Name!@#', 'lowercase')).toBe('fieldname');
+		});
+
+		it('should return original for original convention', () => {
+			expect(applyNamingConvention('Control ID', 'original')).toBe('Control ID');
+			expect(applyNamingConvention('  Trimmed  ', 'original')).toBe('Trimmed');
+		});
+
+		it('should default to camelCase for unknown convention', () => {
+			expect(applyNamingConvention('Control ID', 'unknown')).toBe('controlID');
+		});
+	});
+
+	describe('toCamelCase', () => {
+		it('should convert simple words to camelCase', () => {
+			expect(toCamelCase('control id')).toBe('controlId');
+			expect(toCamelCase('field name')).toBe('fieldName');
+		});
+
+		it('should handle multiple words', () => {
+			expect(toCamelCase('control id field name')).toBe('controlIdFieldName');
+			expect(toCamelCase('this is a test')).toBe('thisIsATest');
+		});
+
+		it('should handle already camelCase strings', () => {
+			expect(toCamelCase('controlId')).toBe('controlId');
+			expect(toCamelCase('alreadyCamelCase')).toBe('alreadyCamelCase');
+		});
+
+		it('should handle strings with special characters', () => {
+			expect(toCamelCase('control-id-field')).toBe('control-Id-Field');
+			expect(toCamelCase('field_name_test')).toBe('field_name_test');
+		});
+
+		it('should handle single words', () => {
+			expect(toCamelCase('control')).toBe('control');
+			expect(toCamelCase('ID')).toBe('iD');
+		});
+
+		it('should handle empty strings', () => {
+			expect(toCamelCase('')).toBe('');
+		});
+	});
+
+	describe('toSnakeCase', () => {
+		it('should convert simple words to snake_case', () => {
+			expect(toSnakeCase('Control ID')).toBe('control_id');
+			expect(toSnakeCase('Field Name')).toBe('field_name');
+		});
+
+		it('should handle multiple words', () => {
+			expect(toSnakeCase('Control ID Field Name')).toBe('control_id_field_name');
+		});
+
+		it('should handle special characters', () => {
+			expect(toSnakeCase('Control-ID@Field#Name')).toBe('control_id_field_name');
+		});
+
+		it('should handle already snake_case strings', () => {
+			expect(toSnakeCase('control_id')).toBe('control_id');
+		});
+
+		it('should handle camelCase input', () => {
+			expect(toSnakeCase('controlIdField')).toBe('controlidfield');
+		});
+
+		it('should handle empty strings', () => {
+			expect(toSnakeCase('')).toBe('');
+		});
+	});
+
+	describe('toKebabCase', () => {
+		it('should convert simple words to kebab-case', () => {
+			expect(toKebabCase('Control ID')).toBe('control-id');
+			expect(toKebabCase('Field Name')).toBe('field-name');
+		});
+
+		it('should handle multiple words', () => {
+			expect(toKebabCase('Control ID Field Name')).toBe('control-id-field-name');
+		});
+
+		it('should handle special characters', () => {
+			expect(toKebabCase('Control@ID#Field%Name')).toBe('control-id-field-name');
+		});
+
+		it('should handle already kebab-case strings', () => {
+			expect(toKebabCase('control-id')).toBe('control-id');
+		});
+
+		it('should handle camelCase input', () => {
+			expect(toKebabCase('controlIdField')).toBe('controlidfield');
+		});
+
+		it('should handle empty strings', () => {
+			expect(toKebabCase('')).toBe('');
+		});
+	});
+
+	describe('detectValueType', () => {
+		it('should detect boolean values', () => {
+			expect(detectValueType(true)).toBe('boolean');
+			expect(detectValueType(false)).toBe('boolean');
+		});
+
+		it('should detect number values', () => {
+			expect(detectValueType(123)).toBe('number');
+			expect(detectValueType(123.456)).toBe('number');
+			expect(detectValueType(0)).toBe('number');
+		});
+
+		it('should detect boolean strings', () => {
+			expect(detectValueType('true')).toBe('boolean');
+			expect(detectValueType('false')).toBe('boolean');
+			expect(detectValueType('TRUE')).toBe('boolean');
+			expect(detectValueType('FALSE')).toBe('boolean');
+			expect(detectValueType('yes')).toBe('boolean');
+			expect(detectValueType('no')).toBe('boolean');
+			expect(detectValueType('y')).toBe('boolean');
+			expect(detectValueType('n')).toBe('boolean');
+			expect(detectValueType('YES')).toBe('boolean');
+			expect(detectValueType('NO')).toBe('boolean');
+		});
+
+		it('should detect number strings', () => {
+			expect(detectValueType('123')).toBe('number');
+			expect(detectValueType('123.456')).toBe('number');
+			expect(detectValueType('-123')).toBe('number');
+			expect(detectValueType('0')).toBe('number');
+		});
+
+		it('should detect date strings', () => {
+			expect(detectValueType('2023-01-01')).toBe('date');
+			expect(detectValueType('12/31/2023')).toBe('date');
+			expect(detectValueType('1/1/23')).toBe('date');
+			expect(detectValueType('01/01/2023')).toBe('date');
+		});
+
+		it('should detect regular strings', () => {
+			expect(detectValueType('hello world')).toBe('string');
+			expect(detectValueType('control description')).toBe('string');
+			expect(detectValueType('AC-1')).toBe('string');
+			expect(detectValueType('')).toBe('string');
+		});
+
+		it('should handle edge cases', () => {
+			expect(detectValueType('   ')).toBe('string'); // Whitespace only
+			expect(detectValueType('123abc')).toBe('string'); // Mixed alphanumeric
+			expect(detectValueType('2023-13-01')).toBe('date'); // This matches date pattern even if invalid
+			expect(detectValueType('maybe')).toBe('string'); // Non-boolean word
+		});
+
+		it('should handle null and undefined', () => {
+			expect(detectValueType(null)).toBe('string');
+			expect(detectValueType(undefined)).toBe('string');
+		});
+	});
+
+	describe('parseCSV', () => {
+		it('should parse simple CSV content', () => {
+			const csvContent = 'Name,Age,City\nJohn,30,NYC\nJane,25,LA';
+			const result = parseCSV(csvContent);
+
+			expect(result).toEqual([
+				['Name', 'Age', 'City'],
+				['John', '30', 'NYC'],
+				['Jane', '25', 'LA']
+			]);
+		});
+
+		it('should handle CSV with quoted fields', () => {
+			const csvContent =
+				'Name,Description\n"John Doe","A person with, comma"\n"Jane Smith","Another ""quoted"" field"';
+			const result = parseCSV(csvContent);
+
+			expect(result).toHaveLength(3); // Header + 2 data rows
+			expect(result[0]).toEqual(['Name', 'Description']);
+		});
+
+		it('should handle empty CSV content', () => {
+			const result = parseCSV('');
+			expect(result).toEqual([]);
+		});
+
+		it('should handle CSV with different line endings', () => {
+			const csvContent = 'Name,Age\r\nJohn,30\r\nJane,25';
+			const result = parseCSV(csvContent);
+
+			expect(result).toHaveLength(3);
+			expect(result[0]).toEqual(['Name', 'Age']);
+		});
+
+		it('should handle malformed CSV gracefully', () => {
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+			// Simulate csv-parse throwing an error
+			const mockParseCSVSync = vi.fn().mockImplementation(() => {
+				throw new Error('Parse error');
+			});
+
+			// Mock the import to throw an error
+			vi.doMock('csv-parse/sync', () => ({
+				parse: mockParseCSVSync
+			}));
+
+			const csvContent = 'Name,Age\nJohn,30,"invalid';
+			const result = parseCSV(csvContent);
+
+			// Should fallback to simple split
+			expect(result).toBeInstanceOf(Array);
+			expect(consoleSpy).toHaveBeenCalledWith('CSV parsing error:', expect.any(Error));
+
+			consoleSpy.mockRestore();
+		});
+
+		it('should skip empty lines when configured', () => {
+			const csvContent = 'Name,Age\n\nJohn,30\n\nJane,25\n';
+			const result = parseCSV(csvContent);
+
+			// Should have header + 2 data rows (empty lines skipped)
+			expect(result).toHaveLength(3);
+			expect(result[1]).toEqual(['John', '30']);
+		});
+	});
+
+	describe('extractFamilyFromControlId', () => {
+		it('should extract family from standard control ID patterns', () => {
+			expect(extractFamilyFromControlId('AC-1')).toBe('AC');
+			expect(extractFamilyFromControlId('AU-2')).toBe('AU');
+			expect(extractFamilyFromControlId('CM-3')).toBe('CM');
+			expect(extractFamilyFromControlId('IA-4')).toBe('IA');
+		});
+
+		it('should handle different delimiters', () => {
+			expect(extractFamilyFromControlId('AC.1')).toBe('AC');
+			expect(extractFamilyFromControlId('AU_2')).toBe('AU');
+			expect(extractFamilyFromControlId('CM 3')).toBe('CM');
+		});
+
+		it('should handle multi-character families', () => {
+			expect(extractFamilyFromControlId('PL-1')).toBe('PL');
+			expect(extractFamilyFromControlId('RA-2')).toBe('RA');
+			expect(extractFamilyFromControlId('SC-3')).toBe('SC');
+			expect(extractFamilyFromControlId('SI-4')).toBe('SI');
+		});
+
+		it('should handle lowercase input', () => {
+			expect(extractFamilyFromControlId('ac-1')).toBe('AC');
+			expect(extractFamilyFromControlId('au-2')).toBe('AU');
+		});
+
+		it('should handle IDs without numbers', () => {
+			expect(extractFamilyFromControlId('ACCESS')).toBe('ACCESS');
+			expect(extractFamilyFromControlId('AUDIT')).toBe('AUDIT');
+		});
+
+		it('should handle empty or invalid input', () => {
+			expect(extractFamilyFromControlId('')).toBe('UNKNOWN');
+			expect(extractFamilyFromControlId(null as any)).toBe('UNKNOWN');
+			expect(extractFamilyFromControlId(undefined as any)).toBe('UNKNOWN');
+		});
+
+		it('should handle IDs starting with numbers', () => {
+			expect(extractFamilyFromControlId('123-TEST')).toBe('12');
+			expect(extractFamilyFromControlId('99')).toBe('99');
+		});
+
+		it('should handle whitespace', () => {
+			expect(extractFamilyFromControlId('  AC-1  ')).toBe('AC');
+			expect(extractFamilyFromControlId('\t\nAU-2\t\n')).toBe('AU');
+		});
+
+		it('should handle complex control IDs', () => {
+			expect(extractFamilyFromControlId('AC-1(1)')).toBe('AC');
+			expect(extractFamilyFromControlId('AU-2.a')).toBe('AU');
+			expect(extractFamilyFromControlId('CM-3 (1) (a)')).toBe('CM');
+		});
+
+		it('should use first two characters as fallback', () => {
+			expect(extractFamilyFromControlId('ABCDEFG')).toBe('ABCDEFG'); // Should get first letter match
+			expect(extractFamilyFromControlId('##')).toBe('##');
+			expect(extractFamilyFromControlId('!@')).toBe('!@');
 		});
 	});
 });

--- a/cli/server/spreadsheetRoutes.ts
+++ b/cli/server/spreadsheetRoutes.ts
@@ -82,6 +82,119 @@ export async function scanControlSets() {
 	return { controlSets };
 }
 
+// Interface for import parameters
+export interface ImportParameters {
+	controlIdField: string;
+	startRow: string;
+	controlSetName: string;
+	controlSetDescription: string;
+	justificationFields: string[];
+	namingConvention: string;
+	skipEmpty: boolean;
+	skipEmptyRows: boolean;
+	frontendFieldSchema: Array<{
+		fieldName: string;
+		tab?: string;
+		displayTab?: string;
+		category?: string;
+		required?: boolean;
+		displayOrder?: number;
+		originalName?: string;
+	}> | null;
+}
+
+// Extract and validate import parameters from request
+export function processImportParameters(reqBody: any): ImportParameters {
+	const {
+		controlIdField = 'Control ID',
+		startRow = '1',
+		controlSetName = 'Imported Control Set',
+		controlSetDescription = 'Imported from spreadsheet'
+	} = reqBody;
+
+	// Parse justification fields if provided
+	let justificationFields: string[] = [];
+	if (reqBody.justificationFields) {
+		try {
+			justificationFields = JSON.parse(reqBody.justificationFields);
+			debug('Justification fields received:', justificationFields);
+		} catch (e) {
+			console.error('Failed to parse justification fields:', e);
+		}
+	}
+
+	// Parse frontend field schema if provided
+	let frontendFieldSchema: Array<{
+		fieldName: string;
+		tab?: string;
+		displayTab?: string;
+		category?: string;
+		required?: boolean;
+		displayOrder?: number;
+		originalName?: string;
+	}> | null = null;
+	if (reqBody.fieldSchema) {
+		try {
+			frontendFieldSchema = JSON.parse(reqBody.fieldSchema);
+		} catch {
+			// Failed to parse fieldSchema
+		}
+	}
+
+	debug('Import parameters received:', {
+		controlIdField,
+		startRow,
+		controlSetName,
+		controlSetDescription
+	});
+
+	return {
+		controlIdField,
+		startRow,
+		controlSetName,
+		controlSetDescription,
+		justificationFields,
+		namingConvention: 'kebab-case',
+		skipEmpty: true,
+		skipEmptyRows: true,
+		frontendFieldSchema
+	};
+}
+
+// Parse uploaded file (CSV or Excel) into raw data
+export async function parseUploadedFile(file: any): Promise<any[][]> {
+	const fileName = file.originalname || '';
+	const isCSV = fileName.toLowerCase().endsWith('.csv');
+	let rawData: any[][] = [];
+
+	if (isCSV) {
+		// Parse CSV file
+		const csvContent = file.buffer.toString('utf-8');
+		rawData = parseCSV(csvContent);
+	} else {
+		// Parse Excel file with ExcelJS
+		const workbook = new ExcelJS.Workbook();
+		const buffer = Buffer.from(file.buffer);
+		await workbook.xlsx.load(buffer as any);
+		const worksheet = workbook.worksheets[0];
+
+		if (!worksheet) {
+			throw new Error('No worksheet found in file');
+		}
+
+		// Convert to array format similar to XLSX
+		worksheet.eachRow({ includeEmpty: true }, (row, rowNumber) => {
+			const rowData: any[] = [];
+			row.eachCell({ includeEmpty: true }, (cell, colNumber) => {
+				rowData[colNumber - 1] = cell.value;
+			});
+			rawData[rowNumber - 1] = rowData;
+		});
+	}
+
+	return rawData;
+}
+
 // Process spreadsheet upload
 router.post('/import-spreadsheet', upload.single('file'), async (req, res) => {
 	try {
@@ -89,68 +202,10 @@ router.post('/import-spreadsheet', upload.single('file'), async (req, res) => {
 			return res.status(400).json({ error: 'No file uploaded' });
 		}
 
-		const {
-			controlIdField = 'Control ID',
-			startRow = '1',
-			controlSetName = 'Imported Control Set',
-			controlSetDescription = 'Imported from spreadsheet'
-		} = req.body;
+		const params = processImportParameters(req.body);
+		const rawData = await parseUploadedFile((req as any).file);
 
-		// Parse justification fields if provided
-		let justificationFields: string[] = [];
-		if (req.body.justificationFields) {
-			try {
-				justificationFields = JSON.parse(req.body.justificationFields);
-				debug('Justification fields received:', justificationFields);
-			} catch (e) {
-				console.error('Failed to parse justification fields:', e);
-			}
-		}
-
-		debug('Import parameters received:', {
-			controlIdField,
-			startRow,
-			controlSetName,
-			controlSetDescription
-		});
-
-		// Hard-coded values
-		const namingConvention = 'kebab-case';
-		const skipEmpty = true;
-		const skipEmptyRows = true;
-
-		// Parse the spreadsheet - handle both CSV and Excel
-		const fileName = (req as any).file.originalname || '';
-		const isCSV = fileName.toLowerCase().endsWith('.csv');
-		let rawData: any[][] = [];
-
-		if (isCSV) {
-			// Parse CSV file
-			const csvContent = (req as any).file.buffer.toString('utf-8');
-			rawData = parseCSV(csvContent);
-		} else {
-			// Parse Excel file with ExcelJS
-			const workbook = new ExcelJS.Workbook();
-			// Convert multer buffer to Node.js Buffer
-			const buffer = Buffer.from((req as any).file.buffer);
-			await workbook.xlsx.load(buffer as any);
-			const worksheet = workbook.worksheets[0];
-
-			if (!worksheet) {
-				return res.status(400).json({ error: 'No worksheet found in file' });
-			}
-
-			// Convert to array format similar to XLSX
-			worksheet.eachRow({ includeEmpty: true }, (row, rowNumber) => {
-				const rowData: any[] = [];
-				row.eachCell({ includeEmpty: true }, (cell, colNumber) => {
-					rowData[colNumber - 1] = cell.value;
-				});
-				rawData[rowNumber - 1] = rowData;
-			});
-		}
-
-		const startRowIndex = parseInt(startRow) - 1;
+		const startRowIndex = parseInt(params.startRow) - 1;
 		if (rawData.length <= startRowIndex) {
 			return res.status(400).json({ error: 'Start row exceeds sheet data' });
 		}
@@ -163,411 +218,26 @@ router.post('/import-spreadsheet', upload.single('file'), async (req, res) => {
 		debug('Headers found:', headers);
 		debug(
 			'After conversion, looking for control ID field:',
-			applyNamingConvention(controlIdField, namingConvention)
+			applyNamingConvention(params.controlIdField, params.namingConvention)
 		);
 
-		// Process rows into controls
-		const controls: SpreadsheetRow[] = [];
-		const families = new Map<string, SpreadsheetRow[]>();
+		// Process the data into controls and metadata
+		const processedData = processSpreadsheetData(rawData, headers, startRowIndex, params);
+		const fieldSchema = buildFieldSchema(
+			processedData.fieldMetadata,
+			processedData.controls,
+			params,
+			processedData.families
+		);
 
-		// Field metadata collection
-		const fieldMetadata = new Map<
-			string,
-			{
-				originalName: string;
-				cleanName: string;
-				type: 'string' | 'number' | 'boolean' | 'date' | 'mixed';
-				maxLength: number;
-				hasMultipleLines: boolean;
-				uniqueValues: Set<unknown>;
-				emptyCount: number;
-				totalCount: number;
-				examples: unknown[];
-			}
-		>();
-
-		// Initialize field metadata for each header
-		headers.forEach((header) => {
-			if (header) {
-				const cleanName = applyNamingConvention(header, namingConvention);
-				fieldMetadata.set(cleanName, {
-					originalName: header,
-					cleanName: cleanName,
-					type: 'string',
-					maxLength: 0,
-					hasMultipleLines: false,
-					uniqueValues: new Set(),
-					emptyCount: 0,
-					totalCount: 0,
-					examples: []
-				});
-			}
-		});
-
-		for (let i = startRowIndex + 1; i < rawData.length; i++) {
-			const row = rawData[i] as unknown[];
-			if (!row || row.length === 0) continue;
-
-			const control: SpreadsheetRow = {};
-			let hasData = false;
-
-			headers.forEach((header, index) => {
-				if (header && row[index] !== undefined && row[index] !== null) {
-					const value = typeof row[index] === 'string' ? row[index].trim() : row[index];
-					const fieldName = applyNamingConvention(header, namingConvention);
-					const metadata = fieldMetadata.get(fieldName)!;
-
-					// Update field metadata
-					metadata.totalCount++;
-
-					if (value === '' || value === null || value === undefined) {
-						metadata.emptyCount++;
-						if (skipEmpty) return;
-					} else {
-						// Track value for metadata - normalize strings for uniqueness detection
-						const normalizedValue = typeof value === 'string' ? value.trim() : value;
-						if (normalizedValue !== '') {
-							// Don't count empty strings as unique values
-							metadata.uniqueValues.add(normalizedValue);
-						}
-
-						// Update type detection
-						const valueType = detectValueType(value);
-						if (metadata.type === 'string' || metadata.totalCount === 1) {
-							metadata.type = valueType;
-						} else if (metadata.type !== valueType) {
-							metadata.type = 'mixed';
-						}
-
-						// Update max length for strings
-						if (typeof value === 'string') {
-							const length = value.length;
-							if (length > metadata.maxLength) {
-								metadata.maxLength = length;
-							}
-
-							// Check for multiple lines
-							if (value.includes('\n') || length > 100) {
-								metadata.hasMultipleLines = true;
-							}
-						}
-
-						// Track a few examples for internal use only (not exported)
-						if (metadata.examples.length < 3 && normalizedValue !== '') {
-							metadata.examples.push(normalizedValue);
-						}
-					}
-
-					control[fieldName] = value;
-					hasData = true;
-				}
-			});
-
-			if (hasData && (!skipEmptyRows || Object.keys(control).length > 0)) {
-				// Extract control ID
-				const controlIdFieldName = applyNamingConvention(controlIdField, namingConvention);
-				// Extract control ID
-				const controlId = control[controlIdFieldName];
-				if (!controlId) {
-					// No control ID found, skipping row
-					continue;
-				}
-
-				// Always extract family from control ID, ignore family field
-				const family = extractFamilyFromControlId(controlId);
-
-				// Don't duplicate the field - just add family
-				control.family = family;
-				controls.push(control);
-
-				// Group by family
-				if (!families.has(family)) {
-					families.set(family, []);
-				}
-				families.get(family)!.push(control);
-			}
-		}
-
-		// Create output directory structure
-		// Use control set name for folder, converted to kebab-case for filesystem compatibility
-		const state = getServerState();
-		const folderName = toKebabCase(controlSetName || 'imported-controls');
-		const baseDir = join(state.CONTROL_SET_DIR || process.cwd(), folderName);
-
-		if (!existsSync(baseDir)) {
-			mkdirSync(baseDir, { recursive: true });
-		}
-
-		// Create lula.yaml with enhanced field metadata
-		const uniqueFamilies = Array.from(families.keys()).filter((f) => f && f !== 'UNKNOWN');
-		// Process families and controls
-
-		// Build field schema from metadata in the expected format
-		// Check if frontend provided field schema with tab assignments
-		let frontendFieldSchema: Array<{
-			fieldName: string;
-			tab?: string;
-			displayTab?: string;
-			category?: string;
-			required?: boolean;
-			displayOrder?: number;
-			originalName?: string;
-		}> | null = null;
-		if (req.body.fieldSchema) {
-			try {
-				frontendFieldSchema = JSON.parse(req.body.fieldSchema);
-			} catch {
-				// Failed to parse fieldSchema
-			}
-		}
-
-		const fields: Record<string, unknown> = {};
-		let displayOrder = 1;
-
-		// Store the control ID field name for the control-set metadata
-		const controlIdFieldNameClean = applyNamingConvention(controlIdField, namingConvention);
-
-		// Family should be a select since it has limited values
-		const familyOptions = Array.from(families.keys())
-			.filter((f) => f && f !== 'UNKNOWN')
-			.sort();
-		fields['family'] = {
-			type: 'string',
-			ui_type: familyOptions.length <= 50 ? 'select' : 'short_text', // Make select if reasonable number of families
-			is_array: false,
-			max_length: 10,
-			usage_count: controls.length,
-			usage_percentage: 100,
-			required: true,
-			visible: true,
-			show_in_table: true,
-			editable: false,
-			display_order: displayOrder++,
-			category: 'core',
-			tab: 'overview'
-		};
-
-		// Add options for family field if it's a select
-		if (familyOptions.length <= 50) {
-			(fields['family'] as any).options = familyOptions;
-		}
-
-		// Add other fields from metadata
-		fieldMetadata.forEach((metadata, fieldName) => {
-			// Skip family as it's already added, and skip 'id' if it would duplicate the control ID field
-			if (fieldName === 'family' || (fieldName === 'id' && controlIdFieldNameClean !== 'id')) {
-				return;
-			}
-
-			// Check if this field was excluded in the frontend (not assigned to any tab)
-			const frontendConfig = frontendFieldSchema?.find((f) => f.fieldName === fieldName);
-			// If we have frontend schema and this field isn't in it, skip it (it was excluded)
-			if (frontendFieldSchema && !frontendConfig) {
-				return;
-			}
-
-			const usageCount = metadata.totalCount - metadata.emptyCount;
-			const usagePercentage =
-				metadata.totalCount > 0 ? Math.round((usageCount / metadata.totalCount) * 100) : 0;
-
-			// Determine UI type based on metadata
-			let uiType = 'short_text';
-
-			// Check for dropdown fields - few unique values with short text and sufficient usage
-			const nonEmptyCount = metadata.totalCount - metadata.emptyCount;
-			const isDropdownCandidate =
-				metadata.uniqueValues.size > 0 &&
-				metadata.uniqueValues.size <= 20 && // Max 20 unique values for dropdown
-				nonEmptyCount >= 10 && // At least 10 non-empty values to be meaningful
-				metadata.maxLength <= 100 && // Reasonably short values only
-				metadata.uniqueValues.size / nonEmptyCount <= 0.3; // Less than 30% unique ratio among non-empty values
-
-			if (metadata.hasMultipleLines || metadata.maxLength > 500) {
-				uiType = 'textarea';
-			} else if (isDropdownCandidate) {
-				uiType = 'select'; // Few unique values suggest a dropdown
-			} else if (metadata.type === 'boolean') {
-				uiType = 'checkbox';
-			} else if (metadata.type === 'number') {
-				uiType = 'number';
-			} else if (metadata.type === 'date') {
-				uiType = 'date';
-			} else if (metadata.maxLength <= 50) {
-				uiType = 'short_text';
-			} else if (metadata.maxLength <= 200) {
-				uiType = 'medium_text';
-			} else {
-				uiType = 'long_text';
-			}
-
-			// Determine category based on field name and usage or use frontend config
-			let category = frontendConfig?.category || 'custom';
-			if (!frontendConfig) {
-				if (fieldName.includes('status') || fieldName.includes('state')) {
-					category = 'compliance';
-				} else if (
-					fieldName.includes('title') ||
-					fieldName.includes('name') ||
-					fieldName.includes('description')
-				) {
-					category = 'core';
-				} else if (fieldName.includes('note') || fieldName.includes('comment')) {
-					category = 'notes';
-				}
-			}
-
-			// Special handling for the control ID field
-			const isControlIdField = fieldName === controlIdFieldNameClean;
-
-			const fieldDef: Record<string, unknown> = {
-				type: metadata.type,
-				ui_type: uiType,
-				is_array: false,
-				max_length: metadata.maxLength,
-				usage_count: usageCount,
-				usage_percentage: usagePercentage,
-				required: isControlIdField ? true : (frontendConfig?.required ?? usagePercentage > 95), // Control ID is always required
-				visible: frontendConfig?.tab !== 'hidden',
-				show_in_table: isControlIdField ? true : metadata.maxLength <= 100 && usagePercentage > 30, // Always show control ID in table
-				editable: isControlIdField ? false : true, // Control ID is not editable
-				display_order: isControlIdField ? 1 : (frontendConfig?.displayOrder ?? displayOrder++), // Control ID is always first
-				category: isControlIdField ? 'core' : category, // Control ID is always core
-				tab: isControlIdField ? 'overview' : frontendConfig?.tab || undefined // Use frontend config or default
-			};
-
-			// Only add options for select fields
-			if (uiType === 'select') {
-				fieldDef.options = Array.from(metadata.uniqueValues).sort();
-			}
-
-			// Add original name if different from field name
-			if (frontendConfig?.originalName || metadata.originalName) {
-				fieldDef.original_name = frontendConfig?.originalName || metadata.originalName;
-			}
-
-			fields[fieldName] = fieldDef;
-		});
-
-		const fieldSchema = {
-			fields: fields,
-			total_controls: controls.length,
-			analyzed_at: new Date().toISOString()
-		};
-
-		const controlSetData = {
-			name: controlSetName,
-			description: controlSetDescription,
-			version: '1.0.0',
-			control_id_field: controlIdFieldNameClean, // Add this to indicate which field is the control ID
-			controlCount: controls.length,
-			families: uniqueFamilies,
-			fieldSchema: fieldSchema
-		};
-
-		writeFileSync(join(baseDir, 'lula.yaml'), yaml.dump(controlSetData));
-
-		// Create controls directory and write individual control files
-		const controlsDir = join(baseDir, 'controls');
-		const mappingsDir = join(baseDir, 'mappings');
-
-		families.forEach((familyControls, family) => {
-			// Create family directories for both controls and mappings
-			const familyDir = join(controlsDir, family);
-			const familyMappingsDir = join(mappingsDir, family);
-
-			if (!existsSync(familyDir)) {
-				mkdirSync(familyDir, { recursive: true });
-			}
-
-			if (!existsSync(familyMappingsDir)) {
-				mkdirSync(familyMappingsDir, { recursive: true });
-			}
-
-			familyControls.forEach((control) => {
-				// Use the control ID field value for the filename
-				const controlId = control[controlIdFieldNameClean];
-
-				if (!controlId) {
-					console.error('Missing control ID for control:', control);
-					return; // Skip this control
-				}
-
-				// Ensure the control ID is a string and limit filename length
-				const controlIdStr = String(controlId).slice(0, 50); // Limit to 50 chars for safety
-				const fileName = `${controlIdStr.replace(/[^a-zA-Z0-9-]/g, '_')}.yaml`;
-				const filePath = join(familyDir, fileName);
-
-				// Create mapping file path
-				const mappingFileName = `${controlIdStr.replace(/[^a-zA-Z0-9-]/g, '_')}-mappings.yaml`;
-				const mappingFilePath = join(familyMappingsDir, mappingFileName);
-
-				// Filter control to only include fields that are in the field schema (not excluded)
-				const filteredControl: SpreadsheetRow = {};
-
-				// Prepare mapping data with empty justification
-				const mappingData: MappingData = {
-					control_id: controlIdStr,
-					justification: '',
-					uuid: crypto.randomUUID()
-				};
-
-				// Collect justification content from all specified fields
-				const justificationContents: string[] = [];
-
-				// Always include family in control file
-				if (control.family !== undefined) {
-					filteredControl.family = control.family;
-				}
-
-				// Include fields that are in the frontend schema or in the fields metadata
-				Object.keys(control).forEach((fieldName) => {
-					// Skip family as it's already added
-					if (fieldName === 'family') return;
-
-					// Check if this field is in the justification fields list
-					if (
-						justificationFields.includes(fieldName) &&
-						control[fieldName] !== undefined &&
-						control[fieldName] !== null
-					) {
-						// Add to justification contents
-						justificationContents.push(control[fieldName]);
-					}
-
-					// Check if field is in the frontend schema (meaning it was assigned to a tab)
-					const isInFrontendSchema = frontendFieldSchema?.some((f) => f.fieldName === fieldName);
-
-					// Check if field is in the fields metadata (core fields)
-					const isInFieldsMetadata = fields.hasOwnProperty(fieldName);
-
-					// Include the field if it's either in frontend schema or fields metadata
-					if (isInFrontendSchema || isInFieldsMetadata) {
-						filteredControl[fieldName] = control[fieldName];
-					}
-				});
-
-				// Write control file
-				writeFileSync(filePath, yaml.dump(filteredControl));
-
-				// Combine all justification contents with line breaks
-				if (justificationContents.length > 0) {
-					mappingData.justification = justificationContents.join('\n\n');
-				}
-
-				// Write mapping file if it has justification content
-				if (mappingData.justification && mappingData.justification.trim() !== '') {
-					// Format as an array with a single mapping entry
-					const mappingArray = [mappingData];
-					writeFileSync(mappingFilePath, yaml.dump(mappingArray));
-				}
-			});
-		});
+		// Create output structure and files
+		const result = await createOutputStructure(processedData, fieldSchema, params);
 
 		res.json({
 			success: true,
-			controlCount: controls.length,
-			families: Array.from(families.keys()),
-			outputDir: folderName // Return just the folder name, not full path
+			controlCount: processedData.controls.length,
+			families: Array.from(processedData.families.keys()),
+			outputDir: result.folderName
 		});
 	} catch (error) {
 		console.error('Error processing spreadsheet:', error);
@@ -575,8 +245,424 @@ router.post('/import-spreadsheet', upload.single('file'), async (req, res) => {
 	}
 });
 
+// Process spreadsheet data into controls and metadata
+export function processSpreadsheetData(
+	rawData: any[][],
+	headers: string[],
+	startRowIndex: number,
+	params: ImportParameters
+) {
+	const controls: SpreadsheetRow[] = [];
+	const families = new Map<string, SpreadsheetRow[]>();
+
+	// Field metadata collection
+	const fieldMetadata = new Map<
+		string,
+		{
+			originalName: string;
+			cleanName: string;
+			type: 'string' | 'number' | 'boolean' | 'date' | 'mixed';
+			maxLength: number;
+			hasMultipleLines: boolean;
+			uniqueValues: Set<unknown>;
+			emptyCount: number;
+			totalCount: number;
+			examples: unknown[];
+		}
+	>();
+
+	// Initialize field metadata for each header
+	headers.forEach((header) => {
+		if (header) {
+			const cleanName = applyNamingConvention(header, params.namingConvention);
+			fieldMetadata.set(cleanName, {
+				originalName: header,
+				cleanName: cleanName,
+				type: 'string',
+				maxLength: 0,
+				hasMultipleLines: false,
+				uniqueValues: new Set(),
+				emptyCount: 0,
+				totalCount: 0,
+				examples: []
+			});
+		}
+	});
+
+	for (let i = startRowIndex + 1; i < rawData.length; i++) {
+		const row = rawData[i] as unknown[];
+		if (!row || row.length === 0) continue;
+
+		const control: SpreadsheetRow = {};
+		let hasData = false;
+
+		headers.forEach((header, index) => {
+			if (header && row[index] !== undefined && row[index] !== null) {
+				const value = typeof row[index] === 'string' ? row[index].trim() : row[index];
+				const fieldName = applyNamingConvention(header, params.namingConvention);
+				const metadata = fieldMetadata.get(fieldName)!;
+
+				// Update field metadata
+				metadata.totalCount++;
+
+				if (value === '' || value === null || value === undefined) {
+					metadata.emptyCount++;
+					if (params.skipEmpty) return;
+				} else {
+					// Track value for metadata - normalize strings for uniqueness detection
+					const normalizedValue = typeof value === 'string' ? value.trim() : value;
+					if (normalizedValue !== '') {
+						// Don't count empty strings as unique values
+						metadata.uniqueValues.add(normalizedValue);
+					}
+
+					// Update type detection
+					const valueType = detectValueType(value);
+					if (metadata.type === 'string' || metadata.totalCount === 1) {
+						metadata.type = valueType;
+					} else if (metadata.type !== valueType) {
+						metadata.type = 'mixed';
+					}
+
+					// Update max length for strings
+					if (typeof value === 'string') {
+						const length = value.length;
+						if (length > metadata.maxLength) {
+							metadata.maxLength = length;
+						}
+
+						// Check for multiple lines
+						if (value.includes('\n') || length > 100) {
+							metadata.hasMultipleLines = true;
+						}
+					}
+
+					// Track a few examples for internal use only (not exported)
+					if (metadata.examples.length < 3 && normalizedValue !== '') {
+						metadata.examples.push(normalizedValue);
+					}
+				}
+
+				control[fieldName] = value;
+				hasData = true;
+			}
+		});
+
+		if (hasData && (!params.skipEmptyRows || Object.keys(control).length > 0)) {
+			// Extract control ID
+			const controlIdFieldName = applyNamingConvention(
+				params.controlIdField,
+				params.namingConvention
+			);
+			// Extract control ID
+			const controlId = control[controlIdFieldName];
+			if (!controlId) {
+				// No control ID found, skipping row
+				continue;
+			}
+
+			// Always extract family from control ID, ignore family field
+			const family = extractFamilyFromControlId(controlId);
+
+			// Don't duplicate the field - just add family
+			control.family = family;
+			controls.push(control);
+
+			// Group by family
+			if (!families.has(family)) {
+				families.set(family, []);
+			}
+			families.get(family)!.push(control);
+		}
+	}
+
+	return { controls, families, fieldMetadata };
+}
+
+// Build field schema from metadata
+export function buildFieldSchema(
+	fieldMetadata: Map<string, any>,
+	controls: SpreadsheetRow[],
+	params: ImportParameters,
+	families: Map<string, SpreadsheetRow[]>
+) {
+	const fields: Record<string, unknown> = {};
+	let displayOrder = 1;
+
+	// Store the control ID field name for the control-set metadata
+	const controlIdFieldNameClean = applyNamingConvention(
+		params.controlIdField,
+		params.namingConvention
+	);
+
+	// Family should be a select since it has limited values
+	const familyOptions = Array.from(families.keys())
+		.filter((f) => f && f !== 'UNKNOWN')
+		.sort();
+	fields['family'] = {
+		type: 'string',
+		ui_type: familyOptions.length <= 50 ? 'select' : 'short_text',
+		is_array: false,
+		max_length: 10,
+		usage_count: controls.length,
+		usage_percentage: 100,
+		required: true,
+		visible: true,
+		show_in_table: true,
+		editable: false,
+		display_order: displayOrder++,
+		category: 'core',
+		tab: 'overview'
+	};
+
+	// Add options for family field if it's a select
+	if (familyOptions.length <= 50) {
+		(fields['family'] as any).options = familyOptions;
+	}
+
+	// Add other fields from metadata
+	fieldMetadata.forEach((metadata, fieldName) => {
+		// Skip family as it's already added, and skip 'id' if it would duplicate the control ID field
+		if (fieldName === 'family' || (fieldName === 'id' && controlIdFieldNameClean !== 'id')) {
+			return;
+		}
+
+		// Check if this field was excluded in the frontend (not assigned to any tab)
+		const frontendConfig = params.frontendFieldSchema?.find((f: any) => f.fieldName === fieldName);
+		// If we have frontend schema and this field isn't in it, skip it (it was excluded)
+		if (params.frontendFieldSchema && !frontendConfig) {
+			return;
+		}
+
+		const usageCount = metadata.totalCount - metadata.emptyCount;
+		const usagePercentage =
+			metadata.totalCount > 0 ? Math.round((usageCount / metadata.totalCount) * 100) : 0;
+
+		// Determine UI type based on metadata
+		let uiType = 'short_text';
+
+		// Check for dropdown fields - few unique values with short text and sufficient usage
+		const nonEmptyCount = metadata.totalCount - metadata.emptyCount;
+		const isDropdownCandidate =
+			metadata.uniqueValues.size > 0 &&
+			metadata.uniqueValues.size <= 20 && // Max 20 unique values for dropdown
+			nonEmptyCount >= 10 && // At least 10 non-empty values to be meaningful
+			metadata.maxLength <= 100 && // Reasonably short values only
+			metadata.uniqueValues.size / nonEmptyCount <= 0.3; // Less than 30% unique ratio among non-empty values
+
+		if (metadata.hasMultipleLines || metadata.maxLength > 500) {
+			uiType = 'textarea';
+		} else if (isDropdownCandidate) {
+			uiType = 'select'; // Few unique values suggest a dropdown
+		} else if (metadata.type === 'boolean') {
+			uiType = 'checkbox';
+		} else if (metadata.type === 'number') {
+			uiType = 'number';
+		} else if (metadata.type === 'date') {
+			uiType = 'date';
+		} else if (metadata.maxLength <= 50) {
+			uiType = 'short_text';
+		} else if (metadata.maxLength <= 200) {
+			uiType = 'medium_text';
+		} else {
+			uiType = 'long_text';
+		}
+
+		// Determine category based on field name and usage or use frontend config
+		let category = frontendConfig?.category || 'custom';
+		if (!frontendConfig) {
+			if (fieldName.includes('status') || fieldName.includes('state')) {
+				category = 'compliance';
+			} else if (
+				fieldName.includes('title') ||
+				fieldName.includes('name') ||
+				fieldName.includes('description')
+			) {
+				category = 'core';
+			} else if (fieldName.includes('note') || fieldName.includes('comment')) {
+				category = 'notes';
+			}
+		}
+
+		// Special handling for the control ID field
+		const isControlIdField = fieldName === controlIdFieldNameClean;
+
+		const fieldDef: Record<string, unknown> = {
+			type: metadata.type,
+			ui_type: uiType,
+			is_array: false,
+			max_length: metadata.maxLength,
+			usage_count: usageCount,
+			usage_percentage: usagePercentage,
+			required: isControlIdField ? true : (frontendConfig?.required ?? usagePercentage > 95),
+			visible: frontendConfig?.tab !== 'hidden',
+			show_in_table: isControlIdField ? true : metadata.maxLength <= 100 && usagePercentage > 30,
+			editable: isControlIdField ? false : true,
+			display_order: isControlIdField ? 1 : (frontendConfig?.displayOrder ?? displayOrder++),
+			category: isControlIdField ? 'core' : category,
+			tab: isControlIdField ? 'overview' : frontendConfig?.tab || undefined
+		};
+
+		// Only add options for select fields
+		if (uiType === 'select') {
+			fieldDef.options = Array.from(metadata.uniqueValues).sort();
+		}
+
+		// Add original name if different from field name
+		if (frontendConfig?.originalName || metadata.originalName) {
+			fieldDef.original_name = frontendConfig?.originalName || metadata.originalName;
+		}
+
+		fields[fieldName] = fieldDef;
+	});
+
+	return {
+		fields: fields,
+		total_controls: controls.length,
+		analyzed_at: new Date().toISOString()
+	};
+}
+
+// Create output directory structure and files
+export async function createOutputStructure(
+	processedData: any,
+	fieldSchema: any,
+	params: ImportParameters
+) {
+	const { controls, families } = processedData;
+
+	// Create output directory structure
+	const state = getServerState();
+	const folderName = toKebabCase(params.controlSetName || 'imported-controls');
+	const baseDir = join(state.CONTROL_SET_DIR || process.cwd(), folderName);
+
+	if (!existsSync(baseDir)) {
+		mkdirSync(baseDir, { recursive: true });
+	}
+
+	// Create lula.yaml with enhanced field metadata
+	const uniqueFamilies = Array.from(families.keys()).filter((f) => f && f !== 'UNKNOWN');
+	const controlIdFieldNameClean = applyNamingConvention(
+		params.controlIdField,
+		params.namingConvention
+	);
+
+	const controlSetData = {
+		name: params.controlSetName,
+		description: params.controlSetDescription,
+		version: '1.0.0',
+		control_id_field: controlIdFieldNameClean,
+		controlCount: controls.length,
+		families: uniqueFamilies,
+		fieldSchema: fieldSchema
+	};
+
+	writeFileSync(join(baseDir, 'lula.yaml'), yaml.dump(controlSetData));
+
+	// Create controls directory and write individual control files
+	const controlsDir = join(baseDir, 'controls');
+	const mappingsDir = join(baseDir, 'mappings');
+
+	families.forEach((familyControls: any, family: any) => {
+		// Create family directories for both controls and mappings
+		const familyDir = join(controlsDir, family);
+		const familyMappingsDir = join(mappingsDir, family);
+
+		if (!existsSync(familyDir)) {
+			mkdirSync(familyDir, { recursive: true });
+		}
+
+		if (!existsSync(familyMappingsDir)) {
+			mkdirSync(familyMappingsDir, { recursive: true });
+		}
+
+		familyControls.forEach((control: any) => {
+			// Use the control ID field value for the filename
+			const controlId = control[controlIdFieldNameClean];
+
+			if (!controlId) {
+				console.error('Missing control ID for control:', control);
+				return; // Skip this control
+			}
+
+			// Ensure the control ID is a string and limit filename length
+			const controlIdStr = String(controlId).slice(0, 50);
+			const fileName = `${controlIdStr.replace(/[^a-zA-Z0-9-]/g, '_')}.yaml`;
+			const filePath = join(familyDir, fileName);
+
+			// Create mapping file path
+			const mappingFileName = `${controlIdStr.replace(/[^a-zA-Z0-9-]/g, '_')}-mappings.yaml`;
+			const mappingFilePath = join(familyMappingsDir, mappingFileName);
+
+			// Filter control to only include fields that are in the field schema (not excluded)
+			const filteredControl: SpreadsheetRow = {};
+
+			// Prepare mapping data with empty justification
+			const mappingData: MappingData = {
+				control_id: controlIdStr,
+				justification: '',
+				uuid: crypto.randomUUID()
+			};
+
+			// Collect justification content from all specified fields
+			const justificationContents: string[] = [];
+
+			// Always include family in control file
+			if (control.family !== undefined) {
+				filteredControl.family = control.family;
+			}
+
+			// Include fields that are in the frontend schema or in the fields metadata
+			Object.keys(control).forEach((fieldName) => {
+				// Skip family as it's already added
+				if (fieldName === 'family') return;
+
+				// Check if this field is in the justification fields list
+				if (
+					params.justificationFields.includes(fieldName) &&
+					control[fieldName] !== undefined &&
+					control[fieldName] !== null
+				) {
+					// Add to justification contents
+					justificationContents.push(control[fieldName]);
+				}
+
+				// Check if field is in the frontend schema (meaning it was assigned to a tab)
+				const isInFrontendSchema = params.frontendFieldSchema?.some(
+					(f: any) => f.fieldName === fieldName
+				);
+
+				// Check if field is in the fields metadata (core fields)
+				const isInFieldsMetadata = fieldSchema.fields.hasOwnProperty(fieldName);
+
+				// Include the field if it's either in frontend schema or fields metadata
+				if (isInFrontendSchema || isInFieldsMetadata) {
+					filteredControl[fieldName] = control[fieldName];
+				}
+			});
+
+			// Write control file
+			writeFileSync(filePath, yaml.dump(filteredControl));
+
+			// Combine all justification contents with line breaks
+			if (justificationContents.length > 0) {
+				mappingData.justification = justificationContents.join('\n\n');
+			}
+
+			// Write mapping file if it has justification content
+			if (mappingData.justification && mappingData.justification.trim() !== '') {
+				// Format as an array with a single mapping entry
+				const mappingArray = [mappingData];
+				writeFileSync(mappingFilePath, yaml.dump(mappingArray));
+			}
+		});
+	});
+
+	return { folderName };
+}
+
 // Helper functions
-function applyNamingConvention(fieldName: string, convention: string): string {
+export function applyNamingConvention(fieldName: string, convention: string): string {
 	if (!fieldName) return fieldName;
 
 	const cleanedName = fieldName.trim();
@@ -597,7 +683,7 @@ function applyNamingConvention(fieldName: string, convention: string): string {
 	}
 }
 
-function toCamelCase(str: string): string {
+export function toCamelCase(str: string): string {
 	return str
 		.replace(/(?:^\w|[A-Z]|\b\w)/g, (word, index) => {
 			return index === 0 ? word.toLowerCase() : word.toUpperCase();
@@ -605,7 +691,7 @@ function toCamelCase(str: string): string {
 		.replace(/\s+/g, '');
 }
 
-function toSnakeCase(str: string): string {
+export function toSnakeCase(str: string): string {
 	return str
 		.replace(/\W+/g, ' ')
 		.split(/ |\s/)
@@ -613,7 +699,7 @@ function toSnakeCase(str: string): string {
 		.join('_');
 }
 
-function toKebabCase(str: string): string {
+export function toKebabCase(str: string): string {
 	return str
 		.replace(/\W+/g, ' ')
 		.split(/ |\s/)
@@ -621,7 +707,7 @@ function toKebabCase(str: string): string {
 		.join('-');
 }
 
-function detectValueType(value: unknown): 'string' | 'number' | 'boolean' | 'date' {
+export function detectValueType(value: unknown): 'string' | 'number' | 'boolean' | 'date' {
 	if (typeof value === 'boolean') return 'boolean';
 	if (typeof value === 'number') return 'number';
 
@@ -660,7 +746,7 @@ function detectValueType(value: unknown): 'string' | 'number' | 'boolean' | 'dat
 }
 
 // Parse CSV content into rows using the csv-parse library
-function parseCSV(content: string): any[][] {
+export function parseCSV(content: string): any[][] {
 	try {
 		// Parse CSV with robust handling of edge cases
 		const records = parseCSVSync(content, {
@@ -688,7 +774,7 @@ function parseCSV(content: string): any[][] {
 	}
 }
 
-function extractFamilyFromControlId(controlId: string): string {
+export function extractFamilyFromControlId(controlId: string): string {
 	if (!controlId) return 'UNKNOWN';
 
 	// Trim any whitespace

--- a/cli/server/spreadsheetRoutes.ts
+++ b/cli/server/spreadsheetRoutes.ts
@@ -136,8 +136,8 @@ export function processImportParameters(reqBody: any): ImportParameters {
 	if (reqBody.fieldSchema) {
 		try {
 			frontendFieldSchema = JSON.parse(reqBody.fieldSchema);
-		} catch {
-			// Failed to parse fieldSchema
+		} catch (e) {
+			console.error('Failed to parse fieldSchema:', e);
 		}
 	}
 


### PR DESCRIPTION
## Description

reduces complexity of import-spreadsheet from 83  and adds test coverage for uncovered functions

```bash
    86:59  warning  Async arrow function has too many statements (83). Maximum allowed is 20 
```

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
