### PR TITLE
fix: consider if review must be dismissed to avoid error in ci

### DIFF
--- a/cli/commands/crawl.ts
+++ b/cli/commands/crawl.ts
@@ -308,7 +308,12 @@ export function crawlCommand(): Command {
 			if (opts.postMode === 'comment') {
 				await deleteOldIssueComments({ octokit, owner, repo, pull_number });
 			} else {
-				await dismissOldReviews({ octokit, owner, repo, pull_number });
+				try {
+					await dismissOldReviews({ octokit, owner, repo, pull_number });
+				} catch (err) {
+					console.error(`Error dismissing old reviews: ${err}`);
+				}
+
 				await deleteOldReviewComments({ octokit, owner, repo, pull_number });
 			}
 			if (leavePost) {

--- a/cli/commands/crawl.ts
+++ b/cli/commands/crawl.ts
@@ -308,12 +308,7 @@ export function crawlCommand(): Command {
 			if (opts.postMode === 'comment') {
 				await deleteOldIssueComments({ octokit, owner, repo, pull_number });
 			} else {
-				try {
-					await dismissOldReviews({ octokit, owner, repo, pull_number });
-				} catch (err) {
-					console.error(`Error dismissing old reviews: ${err}`);
-				}
-
+				await dismissOldReviews({ octokit, owner, repo, pull_number });
 				await deleteOldReviewComments({ octokit, owner, repo, pull_number });
 			}
 			if (leavePost) {
@@ -422,7 +417,9 @@ export async function dismissOldReviews({
 
 		for (const r of reviews) {
 			const hasSignature = (r.body ?? '').includes(LULA_SIGNATURE);
-			if (hasSignature) {
+			const isAlreadyDismissed = r.state === 'DISMISSED';
+
+			if (hasSignature && !isAlreadyDismissed) {
 				await octokit.pulls.dismissReview({
 					owner,
 					repo,


### PR DESCRIPTION
## Description

`npx lula crawl2` will attempt to dismiss existing reviews before deleting them so that every push has a fresh message. However, [you cannot dismiss a dismissed review](https://github.com/defenseunicorns/pepr-excellent-examples/actions/runs/18283958431/job/52053828257?pr=381#step:4:15) (due to the GitHub API), and as a result, the lula crawl workflow fails in CI. This PR checks if the review state is dismissed before actually dismissing.


Here is the [PR](https://github.com/defenseunicorns/pepr-excellent-examples/pull/382) in PEXEX showing that you can dismiss reviews and get a fresh review on the next push 



## Related Issue

Fixes #207 

<!-- or -->

Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
