### PR TITLE
chore: fix some references to pepr

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,4 +19,4 @@ Relates to #
 ## Checklist before merging
 
 - [ ] Test, docs, adr added or updated as needed
-- [ ] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
+- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed

--- a/scripts/nightlies.sh
+++ b/scripts/nightlies.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: 2023-Present The Pepr Authors
-
-# Script to build and publish nightly versions of lula2.
+# SPDX-FileCopyrightText: 2023-Present The Lula Authors
 
 set -e
 


### PR DESCRIPTION
## Description

Removes references to Pepr in PR template and the nightlies.sh header

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://docs.pepr.dev/main/contribute/#submitting-a-pull-request) followed
