### PR TITLE
fix: backticks around lula.yaml to force merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Link controls to actual implementations using a UUID:
 
 ## Configuration
 
-### lula.yaml
+### `lula.yaml`
 
 Managed by the UI for you, each control set includes a configuration file:
 


### PR DESCRIPTION
## Description

Need to force a release to get rid of deprecation warnings. This PR adds backticks to `lula.yaml`

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed
