### PR TITLE
fix: read headers when a new sheet is selected

### DIFF
--- a/cli/server/spreadsheetRoutes.ts
+++ b/cli/server/spreadsheetRoutes.ts
@@ -1510,7 +1510,6 @@ router.post('/parse-excel-sheet', upload.single('file'), async (req, res) => {
 	}
 });
 
-// Get row previews for a specific sheet
 router.post('/parse-excel-sheet-previews', upload.single('file'), async (req, res) => {
 	try {
 		const { sheetName } = req.body;

--- a/cli/server/spreadsheetRoutes.ts
+++ b/cli/server/spreadsheetRoutes.ts
@@ -13,6 +13,8 @@ import { dirname, join, relative } from 'path';
 import { debug } from '../utils/debug';
 import { getServerState, getCurrentControlSetPath } from './serverState';
 
+const MAX_HEADER_CANDIDATES = 5;
+const PREVIEW_COLUMNS = 4;
 // Type definitions
 interface SpreadsheetRow {
 	[key: string]: any;
@@ -1429,11 +1431,11 @@ router.post('/parse-excel', upload.single('file'), async (req, res) => {
 		}
 
 		// Find potential header rows (first 5 non-empty rows)
-		const headerCandidates = rows.slice(0, 5).map((row, index) => ({
+		const headerCandidates = rows.slice(0, MAX_HEADER_CANDIDATES).map((row, index) => ({
 			row: index + 1,
 			preview:
 				row
-					.slice(0, 4)
+					.slice(0, PREVIEW_COLUMNS)
 					.filter((v) => v !== null)
 					.filter((v) => v !== undefined)
 					.join(', ') + (row.length > 4 ? ', ...' : '')
@@ -1536,11 +1538,11 @@ router.post('/parse-excel-sheet-previews', upload.single('file'), async (req, re
 			rows = XLSX.utils.sheet_to_json(worksheet, { header: 1, defval: null });
 		}
 
-		const headerCandidates = rows.slice(0, 5).map((row, index) => ({
+		const headerCandidates = rows.slice(0, MAX_HEADER_CANDIDATES).map((row, index) => ({
 			row: index + 1,
 			preview:
 				row
-					.slice(0, 4)
+					.slice(0, PREVIEW_COLUMNS)
 					.filter((v) => v !== null)
 					.filter((v) => v !== undefined)
 					.join(', ') + (row.length > 4 ? ', ...' : '')

--- a/src/lib/components/setup/SpreadsheetImport.svelte
+++ b/src/lib/components/setup/SpreadsheetImport.svelte
@@ -434,7 +434,7 @@
 			// Add configuration
 			formData.append('controlIdField', controlIdField);
 			formData.append('startRow', headerRow.toString());
-			formData.append('sheetName', selectedSheet); // Add the selected sheet name
+			formData.append('sheetName', selectedSheet);
 			formData.append('namingConvention', 'kebab-case');
 			formData.append('skipEmpty', 'true');
 			formData.append('skipEmptyRows', 'true');
@@ -473,7 +473,6 @@
 				const result = await response.json();
 				successMessage = `Successfully imported ${result.controlCount} controls into ${result.families.length} families`;
 
-				// Dispatch event to parent
 				dispatch('created', { path: result.outputDir });
 			} catch (error) {
 				console.error('Error importing spreadsheet:', error);

--- a/src/lib/components/setup/SpreadsheetImport.svelte
+++ b/src/lib/components/setup/SpreadsheetImport.svelte
@@ -171,6 +171,9 @@
 				if (rowPreviews.length > 0 && !rowPreviews.some((p) => p.row === headerRow)) {
 					headerRow = rowPreviews[0].row;
 				}
+			} else {
+				const error = await previewResponse.json();
+				throw new Error(error.error || 'Failed to load sheet previews');
 			}
 
 			const formData = new FormData();

--- a/src/lib/components/setup/SpreadsheetImport.svelte
+++ b/src/lib/components/setup/SpreadsheetImport.svelte
@@ -155,6 +155,24 @@
 		controlIdField = ''; // Reset control ID field selection
 
 		try {
+			const previewFormData = new FormData();
+			previewFormData.append('file', fileData);
+			previewFormData.append('sheetName', selectedSheet);
+
+			const previewResponse = await fetch('/api/parse-excel-sheet-previews', {
+				method: 'POST',
+				body: previewFormData
+			});
+
+			if (previewResponse.ok) {
+				const previewResult = await previewResponse.json();
+				rowPreviews = previewResult.rowPreviews || [];
+
+				if (rowPreviews.length > 0 && !rowPreviews.some((p) => p.row === headerRow)) {
+					headerRow = rowPreviews[0].row;
+				}
+			}
+
 			const formData = new FormData();
 			formData.append('file', fileData);
 			formData.append('sheetName', selectedSheet);
@@ -615,8 +633,8 @@
 					<select
 						id="sheet"
 						bind:value={selectedSheet}
-						on:change={() => {
-							loadSheetData();
+						on:change={async () => {
+							await loadSheetData();
 						}}
 						class="bg-white border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-600 dark:border-gray-500 dark:text-white"
 					>

--- a/src/lib/components/setup/SpreadsheetImport.svelte
+++ b/src/lib/components/setup/SpreadsheetImport.svelte
@@ -431,6 +431,7 @@
 			// Add configuration
 			formData.append('controlIdField', controlIdField);
 			formData.append('startRow', headerRow.toString());
+			formData.append('sheetName', selectedSheet); // Add the selected sheet name
 			formData.append('namingConvention', 'kebab-case');
 			formData.append('skipEmpty', 'true');
 			formData.append('skipEmptyRows', 'true');


### PR DESCRIPTION
## Description

Reads the headers when a new sheet is selected in an `*.xlsx` sheet. The second problem was that you could not actually upload the sheet because it was looking for the first sheet.


[Test Sheet](https://github.com/user-attachments/files/22782754/fake-controls.xlsx)


## Related Issue

Fixes #222

<!-- or -->

Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed
