### PR TITLE
chore: include lula workflow in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,7 @@ name: Lula Scan
 on:
   pull_request:
     branches: ["main"]
-    # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
-    # labeled is added to support renovate-ready labelling on PRs
-    types: [milestoned, labeled, opened, reopened, synchronize]
+    types: [opened, reopened, synchronize]
 permissions:
   contents: read
   pull-requests: write

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ jobs:
 
       - name: Run Lula Scan
         run: |
-          npx --yes lula2@0.6.3 crawl
+          npx --yes lula2 crawl
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ jobs:
 
       - name: Run Lula Scan
         run: |
-          # renovate: datasource=github-tags depName=defenseunicorns/lula versioning=semver
           npx --yes lula2@0.6.3 crawl
         shell: bash
         env:

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Lula reviewed 2 files changed that affect compliance.
 ```
 
 
-Here is an workflow example for GitHub Actions:
+Here is a workflow example for GitHub Actions:
 
 ```yaml
 # Copyright 2025 Defense Unicorns

--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ Lula reviewed 2 files changed that affect compliance.
 Here is a workflow example for GitHub Actions:
 
 ```yaml
-
 # This workflow runs a Lula scan against the PR to see if compliance has changed
 
 name: Lula Scan

--- a/README.md
+++ b/README.md
@@ -139,6 +139,46 @@ Lula reviewed 2 files changed that affect compliance.
 <sub>**Tip:** Customize your compliance reviews with <a href="https://github.com/defenseunicorns/lula.git" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Lula</a>.</sub>
 ```
 
+
+Here is an workflow example for GitHub Actions:
+
+```yaml
+# Copyright 2025 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+# This workflow runs a Lula scan against the PR to see if compliance has changed
+
+name: Lula Scan
+on:
+  pull_request:
+    branches: ["main"]
+    # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
+    # labeled is added to support renovate-ready labelling on PRs
+    types: [milestoned, labeled, opened, reopened, synchronize]
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  scan-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
+      - name: Use Node.js 22
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22
+
+      - name: Run Lula Scan
+        run: |
+          # renovate: datasource=github-tags depName=defenseunicorns/lula versioning=semver
+          npx --yes lula2@0.6.3 crawl
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
 ### Version Command
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -143,8 +143,6 @@ Lula reviewed 2 files changed that affect compliance.
 Here is a workflow example for GitHub Actions:
 
 ```yaml
-# Copyright 2025 Defense Unicorns
-# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 # This workflow runs a Lula scan against the PR to see if compliance has changed
 


### PR DESCRIPTION
## Description

Since we are starting to publicize Lula, we should include the workflow in the `README.md` so users know how to use it in CI.

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed
