### PR TITLE
fix: considers the original index of the excel or csv to preserve the original order

### DIFF
--- a/cli/server/fileStoreOrder.test.ts
+++ b/cli/server/fileStoreOrder.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { tmpdir } from 'os';
+import { FileStore } from '../../cli/server/infrastructure/fileStore';
+import * as yaml from 'js-yaml';
+
+describe('FileStore Order Preservation', () => {
+	let tempDir: string;
+	let fileStore: FileStore;
+
+	beforeEach(async () => {
+		tempDir = fs.mkdtempSync(path.join(tmpdir(), 'lula-filestore-test-'));
+
+		const metadata = {
+			name: 'Test Control Set',
+			description: 'Test control set for order preservation',
+			version: '1.0.0',
+			control_id_field: 'id',
+			controlOrder: ['AC-3', 'AC-1', 'AC-7', 'AC-2']
+		};
+
+		fs.writeFileSync(path.join(tempDir, 'lula.yaml'), yaml.dump(metadata));
+
+		const controlsDir = path.join(tempDir, 'controls');
+		fs.mkdirSync(controlsDir, { recursive: true });
+
+		const acDir = path.join(controlsDir, 'AC');
+		fs.mkdirSync(acDir, { recursive: true });
+
+		const controls = [
+			{ id: 'AC-1', title: 'Access Control Foundation' },
+			{ id: 'AC-2', title: 'Account Management' },
+			{ id: 'AC-3', title: 'Access Control Policy' },
+			{ id: 'AC-7', title: 'Account Lockout' }
+		];
+
+		controls.forEach((control) => {
+			const filename = `${control.id}.yaml`;
+			const filePath = path.join(acDir, filename);
+			fs.writeFileSync(filePath, yaml.dump(control));
+		});
+
+		fileStore = new FileStore({ baseDir: tempDir });
+	});
+
+	afterEach(() => {
+		if (fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it('should load controls in the order specified by controlOrder metadata', async () => {
+		const controls = await fileStore.loadAllControls();
+
+		const controlIds = controls.map((c) => c.id);
+		const expectedOrder = ['AC-3', 'AC-1', 'AC-7', 'AC-2'];
+
+		expect(controlIds).toEqual(expectedOrder);
+	});
+
+	it('should handle missing controlOrder gracefully', async () => {
+		const metadataPath = path.join(tempDir, 'lula.yaml');
+		const metadata = yaml.load(fs.readFileSync(metadataPath, 'utf8')) as any;
+		delete metadata.controlOrder;
+		fs.writeFileSync(metadataPath, yaml.dump(metadata));
+
+		fileStore = new FileStore({ baseDir: tempDir });
+
+		const controls = await fileStore.loadAllControls();
+
+		expect(controls).toHaveLength(4);
+
+		const controlIds = controls.map((c) => c.id);
+		expect(controlIds).toContain('AC-1');
+		expect(controlIds).toContain('AC-2');
+		expect(controlIds).toContain('AC-3');
+		expect(controlIds).toContain('AC-7');
+	});
+
+	it('should handle controls not in controlOrder by placing them at the end', async () => {
+		const acDir = path.join(tempDir, 'controls', 'AC');
+		const newControl = { id: 'AC-5', title: 'New Control' };
+		const filePath = path.join(acDir, 'AC-5.yaml');
+		fs.writeFileSync(filePath, yaml.dump(newControl));
+
+		fileStore = new FileStore({ baseDir: tempDir });
+
+		const controls = await fileStore.loadAllControls();
+		const controlIds = controls.map((c) => c.id);
+
+		expect(controlIds.slice(0, 4)).toEqual(['AC-3', 'AC-1', 'AC-7', 'AC-2']);
+		expect(controlIds).toContain('AC-5');
+		expect(controlIds).toHaveLength(5);
+	});
+});

--- a/cli/server/infrastructure/fileStore.ts
+++ b/cli/server/infrastructure/fileStore.ts
@@ -322,7 +322,7 @@ export class FileStore {
 				controlOrder = metadata?.controlOrder || null;
 			}
 		} catch (error) {
-			console.error('Failed to load lula.yaml for controlOrder:', error);
+			console.error(`Failed to load lula.yaml for controlOrder (path: ${lulaConfigPath}):`, error);
 		}
 
 		const entries = readdirSync(this.controlsDir);

--- a/cli/server/infrastructure/fileStore.ts
+++ b/cli/server/infrastructure/fileStore.ts
@@ -312,6 +312,19 @@ export class FileStore {
 			return [];
 		}
 
+		// Try to load metadata to get controlOrder if available
+		let controlOrder: string[] | null = null;
+		try {
+			const lulaConfigPath = join(this.baseDir, 'lula.yaml');
+			if (existsSync(lulaConfigPath)) {
+				const content = readFileSync(lulaConfigPath, 'utf8');
+				const metadata = yaml.load(content) as any;
+				controlOrder = metadata?.controlOrder || null;
+			}
+		} catch (error) {
+			console.error('Failed to load lula.yaml for controlOrder:', error);
+		}
+
 		const entries = readdirSync(this.controlsDir);
 
 		// Check for flat structure first (atomic controls)
@@ -335,7 +348,13 @@ export class FileStore {
 			});
 
 			const results = await Promise.all(promises);
-			return results.filter((c): c is Control => c !== null);
+			const controls = results.filter((c): c is Control => c !== null);
+
+			if (controlOrder && controlOrder.length > 0) {
+				return this.sortControlsByOrder(controls, controlOrder);
+			}
+
+			return controls;
 		}
 
 		// Fallback to family-based directory structure
@@ -368,7 +387,30 @@ export class FileStore {
 		}
 
 		const results = await Promise.all(allPromises);
-		return results.filter((c): c is Control => c !== null);
+		const controls = results.filter((c): c is Control => c !== null);
+
+		if (controlOrder && controlOrder.length > 0) {
+			return this.sortControlsByOrder(controls, controlOrder);
+		}
+
+		return controls;
+	}
+
+	/**
+	 * Sort controls based on the provided order array
+	 */
+	private sortControlsByOrder(controls: Control[], controlOrder: string[]): Control[] {
+		// Create a map of control ID to index in the order array
+		const orderMap = new Map<string, number>();
+		controlOrder.forEach((controlId, index) => {
+			orderMap.set(controlId, index);
+		});
+
+		return controls.sort((a, b) => {
+			const aIndex = orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER;
+			const bIndex = orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER;
+			return aIndex - bIndex;
+		});
 	}
 
 	/**

--- a/cli/server/spreadsheetOrder.test.ts
+++ b/cli/server/spreadsheetOrder.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import {
+	processSpreadsheetData,
+	parseCSV,
+	processImportParameters
+} from '../../cli/server/spreadsheetRoutes';
+import { tmpdir } from 'os';
+
+describe('CSV Import Order Preservation', () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(tmpdir(), 'lula-test-'));
+	});
+
+	afterEach(() => {
+		if (fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it('should preserve the original spreadsheet row order', () => {
+		const csvContent = `Control ID,Title,Description
+AC-3,Access Control Policy,Develop and maintain access control policy
+AC-1,Access Control Foundation,Foundation for access control
+AC-7,Account Lockout,Implement account lockout measures
+AC-2,Account Management,Manage user accounts and access
+AC-15,Remote Access Control,Control remote access to systems
+AC-6,Least Privilege,Implement least privilege principle`;
+
+		const rawData = parseCSV(csvContent);
+		const headers = rawData[0] as string[];
+
+		const params = processImportParameters({
+			controlIdField: 'Control ID',
+			startRow: '1',
+			controlSetName: 'Test Control Set',
+			controlSetDescription: 'Test control set for order preservation'
+		});
+
+		const processedData = processSpreadsheetData(rawData, headers, 0, params);
+
+		const expectedOrder = ['AC-3', 'AC-1', 'AC-7', 'AC-2', 'AC-15', 'AC-6'];
+		const actualOrder = processedData.controls.map((control: any) => control['control-id']);
+
+		expect(actualOrder).toEqual(expectedOrder);
+
+		processedData.controls.forEach((control: any, index: number) => {
+			expect(control._originalRowIndex).toBe(index + 1); // +1 because row 0 is headers
+		});
+
+		const sortedControls = [...processedData.controls].sort(
+			(a: any, b: any) => (a._originalRowIndex || 0) - (b._originalRowIndex || 0)
+		);
+		const sortedOrder = sortedControls.map((control: any) => control['control-id']);
+		expect(sortedOrder).toEqual(expectedOrder);
+	});
+
+	it('should preserve order within families', () => {
+		const csvContent = `Control ID,Title,Description
+CA-3,Security Assessment,Conduct security assessments
+AC-1,Access Control Foundation,Foundation for access control
+CA-1,Assessment Planning,Plan security assessments
+AC-3,Access Control Policy,Develop and maintain access control policy
+CA-7,Continuous Monitoring,Implement continuous monitoring
+AC-2,Account Management,Manage user accounts and access`;
+
+		const rawData = parseCSV(csvContent);
+		const headers = rawData[0] as string[];
+
+		const params = processImportParameters({
+			controlIdField: 'Control ID',
+			startRow: '1',
+			controlSetName: 'Test Mixed Families',
+			controlSetDescription: 'Test mixed families for order preservation'
+		});
+
+		const processedData = processSpreadsheetData(rawData, headers, 0, params);
+
+		const acControls = processedData.families.get('AC') || [];
+		const acOrder = acControls.map((control: any) => control['control-id']);
+		expect(acOrder).toEqual(['AC-1', 'AC-3', 'AC-2']);
+
+		const caControls = processedData.families.get('CA') || [];
+		const caOrder = caControls.map((control: any) => control['control-id']);
+		expect(caOrder).toEqual(['CA-3', 'CA-1', 'CA-7']);
+	});
+});


### PR DESCRIPTION
## Description

This fixes a pain-point from the way the ordering is currently happening in the UI. This PR considers the original index and sorts controls based on that index.

If we want to use this feature retro-actively then we can bring in this [PR](https://github.com/defenseunicorns/uds-compliance/pull/65)

## Related Issue

Fixes #231 

<!-- or -->

Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed
