### PR TITLE
fix: reset data on loadsheetdata

### DIFF
--- a/src/lib/components/setup/SpreadsheetImport.svelte
+++ b/src/lib/components/setup/SpreadsheetImport.svelte
@@ -154,6 +154,11 @@
 		fieldConfigs = new Map(); // Force reactivity
 		controlIdField = ''; // Reset control ID field selection
 
+		justificationFields = [];
+		draggedField = null;
+		dragOverTab = null;
+		dragOverField = null;
+
 		try {
 			const previewFormData = new FormData();
 			previewFormData.append('file', fileData);


### PR DESCRIPTION
## Description

When your excel file has multiple sheets, if you have drug fields into custom columns the data would sometimes persist. This PR resets the justificationFields after loading a new sheet.

[fake-controls.xlsx](https://github.com/user-attachments/files/22912605/fake-controls.xlsx)

The way to test this PR is to:

```bash
> pnpm run build && npx lula2
```

Drag some columns for the initial sheet, then change the sheet and verify that the state has been reset.


## Related Issue

Fixes #230 

<!-- or -->

Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed
