### PR TITLE
fix: export only if dialog is open

### DIFF
--- a/src/lib/components/dialogs/ExportColumnDialog.svelte
+++ b/src/lib/components/dialogs/ExportColumnDialog.svelte
@@ -43,8 +43,8 @@
 			setTimeout(() => node.focus(), 0);
 		}
 		return {
-			update(newIsOpen: boolean) {
-				if (newIsOpen) {
+			update() {
+				if (isOpen) {
 					setTimeout(() => node.focus(), 0);
 				}
 			}
@@ -62,6 +62,8 @@
 	}
 
 	function handleKeydown(event: KeyboardEvent) {
+		if (!isOpen) return;
+		
 		if (event.key === 'Escape') {
 			handleCancel();
 		} else if (event.key === 'Enter') {
@@ -125,7 +127,7 @@
 					</label>
 					<select
 						id="column-select"
-						use:focusSelect={isOpen}
+						use:focusSelect
 						bind:value={selectedColumn}
 						class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
 					>

--- a/src/lib/components/dialogs/ExportColumnDialog.svelte
+++ b/src/lib/components/dialogs/ExportColumnDialog.svelte
@@ -83,7 +83,7 @@
 {#if isOpen}
 	<!-- Modal Backdrop -->
 	<div
-		class="fixed inset-0 bg-gray-700 dark:bg-gray-900 bg-opacity-50 dark:bg-opacity-75 overflow-y-auto h-full w-full z-50 flex items-center justify-center p-4"
+		class="fixed inset-0 overflow-y-auto h-full w-full z-50 flex items-center justify-center p-4"
 		role="dialog"
 		aria-modal="true"
 		tabindex="-1"

--- a/src/lib/components/dialogs/ExportColumnDialog.svelte
+++ b/src/lib/components/dialogs/ExportColumnDialog.svelte
@@ -63,7 +63,7 @@
 
 	function handleKeydown(event: KeyboardEvent) {
 		if (!isOpen) return;
-		
+
 		if (event.key === 'Escape') {
 			handleCancel();
 		} else if (event.key === 'Enter') {


### PR DESCRIPTION
## Description

The `ExportColumnDialog` had a global window keydown handler that was always active bc it is in `+layout.svelte`, so we needed to check if it was open before taking any actions in that component on key events.

I changed the update too because it does not rely on any parameters since it uses `use:focusSelected` and it uses the reactive `isOpen`.


https://svelte.dev/docs/svelte/svelte-action#ActionReturn The update is a property on ActionReturn.

## Related Issue

Fixes https://github.com/defenseunicorns/lula/issues/245

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed
