### PR TITLE
chore: update CODEOWNERS to 'lula'

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @defenseunicorns/uds-core @defenseunicorns/pepr
+* @defenseunicorns/lula
 
 # Additional privileged files
 /CODEOWNERS @jeff-mccoy @daveworth

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @defenseunicorns/uds-core @defenseunicorns/lula
+* @defenseunicorns/uds-core
 
 # Additional privileged files
 /CODEOWNERS @jeff-mccoy @daveworth

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @defenseunicorns/lula
+* @defenseunicorns/uds-core @defenseunicorns/lula
 
 # Additional privileged files
 /CODEOWNERS @jeff-mccoy @daveworth


### PR DESCRIPTION
## Description

this PR relates to #247. the `@defenseunicorns/lula` team MUST be created prior to merge.

## Related Issue

Fixes #247 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed
