### PR TITLE
chore: fix dependabot and @sveltejs/vite-plugin-svelte

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: '22.x'
+          node-version: '22.20.x'
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: '22.x'
+          node-version: '22.20.x'
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/on-demand-workflows.yaml
+++ b/.github/workflows/on-demand-workflows.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: '22.x'
+          node-version: '22.20.x'
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: '22.x'
+          node-version: '22.20.x'
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
@@ -102,7 +102,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: '22.x'
+          node-version: '22.20.x'
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,12 +12,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 9
+        run_install: false
+
     - name: Setup Node.js
       uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
       with:
-        node-version: lts/*
+        node-version: '22.20.x'
+        cache: 'pnpm'
+        cache-dependency-path: 'pnpm-lock.yaml'
     - name: Install dependencies
-      run: npm install -g pnpm && pnpm install
+      run: pnpm install
     - name: Install Playwright Browsers
       run: pnpm exec playwright install --with-deps
     - name: Run Playwright tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: '22.x'
+          node-version: '22.20.x'
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ families:
 
 ### Prerequisites
 
-- Node.js 22+
+- Node.js 22.20.x or >= 24.x
 - Git (for version history features)
 - pnpm (recommended) or npm
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "types": "dist/index.d.ts",
   "type": "module",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.20.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

This should fix dependabot and `@sveltejs/vite-plugin-svelte` which needs 


`@sveltejs/vite-plugin-svelte` needs:
```bash
^20.19 || ^22.12 || >=24
Got: v22.9.0
```

Dependabot [v22.20.0](https://github.com/defenseunicorns/lula/network/updates/1127538279)


[Problem PR](https://github.com/defenseunicorns/lula/pull/253)

## Related Issue

Fixes #255 

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed
