### PR TITLE
fix: use pr head instead of main

### DIFF
--- a/cli/commands/crawl.test.ts
+++ b/cli/commands/crawl.test.ts
@@ -486,7 +486,6 @@ describe('crawl command (integration)', () => {
 				const content = Buffer.from(regularFileOld, 'utf8').toString('base64');
 				return Promise.resolve({ data: { content } });
 			}
-			// New text should be fetched using HEAD SHA
 			if (path === 'src/regular.txt' && ref === 'head-sha-456') {
 				const content = Buffer.from(regularFileNew, 'utf8').toString('base64');
 				return Promise.resolve({ data: { content } });

--- a/cli/commands/crawl.test.ts
+++ b/cli/commands/crawl.test.ts
@@ -90,7 +90,6 @@ beforeEach(() => {
 	pullsListReviews.mockResolvedValue({ data: [] });
 	pullsDismissReview.mockResolvedValue({});
 
-	// Default PR payload includes head.sha so SHA-based refs work by default
 	pullsGet.mockResolvedValue({
 		data: { head: { ref: 'main', sha: 'main-sha' }, base: { sha: 'base-sha-123' } }
 	});


### PR DESCRIPTION
## Description

Crawl against head of PR branch bc we are getting false positives when the branch is not up to date.  This should ensure that only code that the PR author changed will flag. Effectively this is the head vs the base sha

## Related Issue

Fixes #254 

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed
