### PR TITLE
chore: fix nightlies that were failing due a node warning getting captured in stdout

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -39,7 +39,6 @@ jobs:
           node-version: '24.x'
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Ensure pnpm store exists
         run: pnpm store path | xargs -I{} mkdir -p "{}"

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: '22.20.x'
+          node-version: '24.x'
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -54,4 +54,7 @@ jobs:
       - name: Publish to NPM
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: ./scripts/nightlies.sh
+        shell: bash
+        run: |
+          set -x
+          ./scripts/nightlies.sh

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -40,7 +40,6 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
           registry-url: 'https://registry.npmjs.org'
-          always-auth: true
 
       - name: Ensure pnpm store exists
         run: pnpm store path | xargs -I{} mkdir -p "{}"

--- a/scripts/nightlies.sh
+++ b/scripts/nightlies.sh
@@ -7,7 +7,14 @@ set -Eeuo pipefail
 trap 'echo "Error on line $LINENO (exit $?)" >&2' ERR
 set -x
 
-LATEST_VERSION=$(npx --yes lula2@latest --version 2>/dev/null)
+if LATEST_VERSION="$(npx --yes lula2@latest --version 2>&1)"; then
+  echo "LATEST_VERSION=${LATEST_VERSION}"
+else
+  echo "npx lula2@latest --version failed:"
+  echo "${LATEST_VERSION}" >&2
+  exit 1
+fi
+
 RAW_NIGHTLY_VERSION=$(npx --yes lula2@nightly --version 2>/dev/null || echo "none")
 
 if [[ "$RAW_NIGHTLY_VERSION" == "none" ]]; then

--- a/scripts/nightlies.sh
+++ b/scripts/nightlies.sh
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2023-Present The Lula Authors
 
-set -e
+set -Eeuo pipefail
+trap 'echo "Error on line $LINENO (exit $?)" >&2' ERR
+set -x
 
 LATEST_VERSION=$(npx --yes lula2@latest --version 2>/dev/null)
 RAW_NIGHTLY_VERSION=$(npx --yes lula2@nightly --version 2>/dev/null || echo "none")


### PR DESCRIPTION
## Description

Nightlies have been failing for over the last week. There was a warning that was getting caught in the output so the version could not be determined.

[Last nightlies.](https://github.com/defenseunicorns/lula/actions/workflows/nightlies.yml)

## Related Issue

Fixes #

<!-- or -->

Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed
