### PR TITLE
fix: crawl command is giving false positives

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Commenting regarding `integration/test-files/ex.yaml`.
 Posted (comment)
 ----------------
 
+<!-- LULA_SIGNATURE:v1 -->
 ## Lula Compliance Overview
 
 Please review the changes to ensure they meet compliance standards.
@@ -120,8 +121,13 @@ Lula reviewed 2 files changed that affect compliance.
 | File | Lines Changed |
 | ---- | ------------- |
 | `integration/test-files/ex.ts` | `20–31` |
-> **uuid**-`123e4567-e89b-12d3-a456-426614174000`
- **sha256** `f889702fd3330d939fadb5f37087948e42a840d229646523989778e2b1586926`
+| `integration/test-files/ex.ts` | `39–47` |
+
+**UUID:** `123e4567-e89b-12d3-a456-426614174000`
+**sha256:** `f889702fd3330d939fadb5f37087948e42a840d229646523989778e2b1586926`
+
+**UUID:** `987e4567-e89b-12d3-a456-426614174777`
+**sha256:** `72acd6ffeab63567b4fc38ffb1997d106d30c0cec4474d8046810dcbcbb1302b`
 
 
 
@@ -129,8 +135,13 @@ Lula reviewed 2 files changed that affect compliance.
 | File | Lines Changed |
 | ---- | ------------- |
 | `integration/test-files/ex.yaml` | `1–5` |
-> **uuid**-`123e4567-e89b-12d3-a456-426614174001`
- **sha256** `f6b6f51335248062b003696623bfe21cea977ca7f4e4163b182b0036fa699eb4`
+| `integration/test-files/ex.yaml` | `8–14` |
+
+**UUID:** `123e4567-e89b-12d3-a456-426614174001`
+**sha256:** `f6b6f51335248062b003696623bfe21cea977ca7f4e4163b182b0036fa699eb4`
+
+**UUID:** `987e4567-e89b-12d3-a456-426614174777`
+**sha256:** `ab0240ce74fa7aec548e671a24c5cdede388970a95eb1198b6eb7cb1c8635cef`
 
 
 

--- a/cli/commands/crawl.test.ts
+++ b/cli/commands/crawl.test.ts
@@ -1005,7 +1005,8 @@ describe('Refactored crawl functions', () => {
 
 			expect(result).toContain('| File | Lines Changed |');
 			expect(result).toContain('| `test.js` | `6–10` |');
-			expect(result).toContain('**Block `abc123` sha256:**');
+			expect(result).toContain('**UUID:** `abc123`');
+			expect(result).toContain('**sha256:**');
 			expect(logSpy).toHaveBeenCalledWith('Commenting regarding `test.js`.');
 		});
 
@@ -1026,9 +1027,10 @@ describe('Refactored crawl functions', () => {
 			expect(result).toContain('| `test.js` | `1–2` |');
 			expect(result).toContain('| `test.js` | `6–7` |');
 
-			// Should have separate sha256 blocks after the table
-			expect(result).toContain('**Block `abc123` sha256:**');
-			expect(result).toContain('**Block `def456` sha256:**');
+			// Should have separate block and sha256 entries after the table
+			expect(result).toContain('**UUID:** `abc123`');
+			expect(result).toContain('**UUID:** `def456`');
+			expect(result).toContain('**sha256:**');
 
 			// Should only log once per call to the function
 			expect(logSpy).toHaveBeenCalledWith('Commenting regarding `test.js`.');
@@ -1065,9 +1067,10 @@ describe('Refactored crawl functions', () => {
 			expect(result).toContain('| `test.js` | `1–3` | `abc123` |');
 			expect(result).toContain('| `test.js` | `6–8` | `def456` |');
 
-			// Should have separate sha256 blocks after the table
-			expect(result).toContain('**Block `abc123` sha256:**');
-			expect(result).toContain('**Block `def456` sha256:**');
+			// Should have separate block and sha256 entries after the table
+			expect(result).toContain('**UUID:** `abc123`');
+			expect(result).toContain('**UUID:** `def456`');
+			expect(result).toContain('**sha256:**');
 
 			expect(result).toContain('removal of these compliance annotations is intentional');
 			expect(logSpy).toHaveBeenCalledWith('Found removed annotations in `test.js`.');

--- a/cli/commands/crawl.test.ts
+++ b/cli/commands/crawl.test.ts
@@ -1005,12 +1005,11 @@ describe('Refactored crawl functions', () => {
 
 			expect(result).toContain('| File | Lines Changed |');
 			expect(result).toContain('| `test.js` | `6–10` |');
-			expect(result).toContain('**uuid**-`abc123`');
-			expect(result).toContain('**sha256**');
+			expect(result).toContain('**Block `abc123` sha256:**');
 			expect(logSpy).toHaveBeenCalledWith('Commenting regarding `test.js`.');
 		});
 
-		it('should generate content for multiple changed blocks', () => {
+		it('should generate content for multiple changed blocks with consolidated table', () => {
 			const changedBlocks = [
 				{ uuid: 'abc123', startLine: 0, endLine: 2 },
 				{ uuid: 'def456', startLine: 5, endLine: 7 }
@@ -1019,11 +1018,20 @@ describe('Refactored crawl functions', () => {
 
 			const result = generateChangedBlocksContent('test.js', changedBlocks, newText);
 
+			// Should have one table header
+			const tableHeaderMatches = result.match(/\| File \| Lines Changed \|/g);
+			expect(tableHeaderMatches).toHaveLength(1);
+
+			// Should contain both rows in the same table
 			expect(result).toContain('| `test.js` | `1–2` |');
-			expect(result).toContain('**uuid**-`abc123`');
 			expect(result).toContain('| `test.js` | `6–7` |');
-			expect(result).toContain('**uuid**-`def456`');
-			expect(logSpy).toHaveBeenCalledTimes(2);
+
+			// Should have separate sha256 blocks after the table
+			expect(result).toContain('**Block `abc123` sha256:**');
+			expect(result).toContain('**Block `def456` sha256:**');
+
+			// Should only log once per call to the function
+			expect(logSpy).toHaveBeenCalledWith('Commenting regarding `test.js`.');
 		});
 
 		it('should return empty string for no changed blocks', () => {
@@ -1038,7 +1046,7 @@ describe('Refactored crawl functions', () => {
 			expect(result).toBe('');
 		});
 
-		it('should generate content for removed blocks', () => {
+		it('should generate content for removed blocks with consolidated table', () => {
 			const removedBlocks = [
 				{ uuid: 'abc123', startLine: 0, endLine: 3 },
 				{ uuid: 'def456', startLine: 5, endLine: 8 }
@@ -1048,10 +1056,19 @@ describe('Refactored crawl functions', () => {
 			const result = generateRemovedBlocksContent('test.js', removedBlocks, oldText);
 
 			expect(result).toContain('Lula annotations were removed from `test.js`');
-			expect(result).toContain('| File | Original Lines | UUID |');
+
+			// Should have one table header
+			const tableHeaderMatches = result.match(/\| File \| Original Lines \| UUID \|/g);
+			expect(tableHeaderMatches).toHaveLength(1);
+
+			// Should contain both rows in the same table
 			expect(result).toContain('| `test.js` | `1–3` | `abc123` |');
 			expect(result).toContain('| `test.js` | `6–8` | `def456` |');
-			expect(result).toContain('**sha256**');
+
+			// Should have separate sha256 blocks after the table
+			expect(result).toContain('**Block `abc123` sha256:**');
+			expect(result).toContain('**Block `def456` sha256:**');
+
 			expect(result).toContain('removal of these compliance annotations is intentional');
 			expect(logSpy).toHaveBeenCalledWith('Found removed annotations in `test.js`.');
 		});

--- a/cli/commands/crawl.test.ts
+++ b/cli/commands/crawl.test.ts
@@ -253,6 +253,60 @@ describe('extractMapBlocks & getChangedBlocks', () => {
 		const changed = getChangedBlocks(oldText, newText);
 		expect(changed).toHaveLength(0);
 	});
+
+	it('should not detect changes when lines are inserted above a block (line shift scenario)', () => {
+		const uuid = '123e4567-e89b-12d3-a456-426614174000';
+		
+		const oldText = [
+			'header',
+			`// @lulaStart ${uuid}`,
+			'unchanged content line 1',
+			'unchanged content line 2',
+			`// @lulaEnd ${uuid}`,
+			'footer'
+		].join('\n');
+
+		const newTextWithInsertionAbove = [
+			'header',
+			'NEWLY INSERTED LINE 1',
+			'NEWLY INSERTED LINE 2',
+			`// @lulaStart ${uuid}`,
+			'unchanged content line 1',
+			'unchanged content line 2',
+			`// @lulaEnd ${uuid}`,
+			'footer'
+		].join('\n');
+
+		const changed = getChangedBlocks(oldText, newTextWithInsertionAbove);
+		expect(changed).toHaveLength(0);
+	});
+
+	it('should detect actual content changes within a block even when line positions shift', () => {
+		const uuid = '123e4567-e89b-12d3-a456-426614174000';
+		
+		const oldText = [
+			'header',
+			`// @lulaStart ${uuid}`,
+			'original content line 1',
+			'original content line 2',
+			`// @lulaEnd ${uuid}`,
+			'footer'
+		].join('\n');
+
+		const newTextWithInsertionAndChange = [
+			'header',
+			'NEWLY INSERTED LINE',
+			`// @lulaStart ${uuid}`,
+			'CHANGED content line 1', 
+			'original content line 2',
+			`// @lulaEnd ${uuid}`,
+			'footer'
+		].join('\n');
+
+		const changed = getChangedBlocks(oldText, newTextWithInsertionAndChange);
+		expect(changed).toHaveLength(1);
+		expect(changed[0].uuid).toBe(uuid);
+	});
 });
 
 describe('getRemovedBlocks', () => {

--- a/cli/commands/crawl.test.ts
+++ b/cli/commands/crawl.test.ts
@@ -256,7 +256,7 @@ describe('extractMapBlocks & getChangedBlocks', () => {
 
 	it('should not detect changes when lines are inserted above a block (line shift scenario)', () => {
 		const uuid = '123e4567-e89b-12d3-a456-426614174000';
-		
+
 		const oldText = [
 			'header',
 			`// @lulaStart ${uuid}`,
@@ -283,7 +283,7 @@ describe('extractMapBlocks & getChangedBlocks', () => {
 
 	it('should detect actual content changes within a block even when line positions shift', () => {
 		const uuid = '123e4567-e89b-12d3-a456-426614174000';
-		
+
 		const oldText = [
 			'header',
 			`// @lulaStart ${uuid}`,
@@ -297,7 +297,7 @@ describe('extractMapBlocks & getChangedBlocks', () => {
 			'header',
 			'NEWLY INSERTED LINE',
 			`// @lulaStart ${uuid}`,
-			'CHANGED content line 1', 
+			'CHANGED content line 1',
 			'original content line 2',
 			`// @lulaEnd ${uuid}`,
 			'footer'

--- a/cli/commands/crawl.ts
+++ b/cli/commands/crawl.ts
@@ -15,7 +15,7 @@ type FileContentResponse = {
  * Interface for GitHub pull request file objects
  */
 export interface PullRequestFile {
-	sha: string;
+	sha: string | null;
 	filename: string;
 	status: 'added' | 'removed' | 'modified' | 'renamed' | 'copied' | 'changed' | 'unchanged';
 	additions: number;
@@ -201,19 +201,35 @@ export function getChangedBlocks(
 	const newBlocks = extractMapBlocks(newText);
 	const changed = [];
 
+	const oldLines = oldText.split('\n');
+	const newLines = newText.split('\n');
+
 	for (const newBlock of newBlocks) {
 		const oldMatch = oldBlocks.find((b) => b.uuid === newBlock.uuid);
 		if (!oldMatch) continue;
 
-		const oldSegment = oldText.split('\n').slice(oldMatch.startLine, oldMatch.endLine).join('\n');
-		const newSegment = newText.split('\n').slice(newBlock.startLine, newBlock.endLine).join('\n');
+		
+		const oldContent = extractBlockContent(oldLines, oldMatch.startLine, oldMatch.endLine);
+		const newContent = extractBlockContent(newLines, newBlock.startLine, newBlock.endLine);
 
-		if (oldSegment !== newSegment) {
+		if (oldContent !== newContent) {
 			changed.push(newBlock);
 		}
 	}
 
 	return changed;
+}
+
+/**
+ * Extract the content between @lulaStart and @lulaEnd
+ *
+ * @param lines The array of lines.
+ * @param startLine The line number of @lulaStart 
+ * @param endLine The line number of @lulaEnd 
+ * @returns The content between the annotations as a string.
+ */
+function extractBlockContent(lines: string[], startLine: number, endLine: number): string {
+	return lines.slice(startLine + 1, endLine - 1).join('\n');
 }
 
 /**

--- a/cli/commands/crawl.ts
+++ b/cli/commands/crawl.ts
@@ -365,14 +365,23 @@ export function generateChangedBlocksContent(
 	changedBlocks: { uuid: string; startLine: number; endLine: number }[],
 	newText: string
 ): string {
-	let content = '';
+	if (changedBlocks.length === 0) {
+		return '';
+	}
+
+	console.log(`Commenting regarding \`${filename}\`.`);
+
+	let content = `\n\n---\n| File | Lines Changed |\n| ---- | ------------- |\n`;
 
 	for (const block of changedBlocks) {
-		console.log(`Commenting regarding \`${filename}\`.`);
-		content += `\n\n---\n| File | Lines Changed |\n` + `| ---- | ------------- |\n`;
+		content += `| \`${filename}\` | \`${block.startLine + 1}–${block.endLine}\` |\n`;
+	}
+
+	content += `\n`;
+	for (const block of changedBlocks) {
 		const newBlockText = newText.split('\n').slice(block.startLine, block.endLine).join('\n');
 		const blockSha256 = createHash('sha256').update(newBlockText).digest('hex');
-		content += `| \`${filename}\` | \`${block.startLine + 1}–${block.endLine}\` |\n> **uuid**-\`${block.uuid}\`\n **sha256** \`${blockSha256}\`\n\n`;
+		content += `**Block \`${block.uuid}\` sha256:** \`${blockSha256}\`\n\n`;
 	}
 
 	return content;
@@ -398,11 +407,17 @@ export function generateRemovedBlocksContent(
 	content += `| File | Original Lines | UUID |\n`;
 	content += `| ---- | -------------- | ---- |\n`;
 
+	// First, generate all table rows
+	for (const block of removedBlocks) {
+		content += `| \`${filename}\` | \`${block.startLine + 1}–${block.endLine}\` | \`${block.uuid}\` |\n`;
+	}
+
+	// Then add sha256 information for each block after the table
+	content += `\n`;
 	for (const block of removedBlocks) {
 		const oldBlockText = oldText.split('\n').slice(block.startLine, block.endLine).join('\n');
 		const blockSha256 = createHash('sha256').update(oldBlockText).digest('hex');
-		content += `| \`${filename}\` | \`${block.startLine + 1}–${block.endLine}\` | \`${block.uuid}\` |\n`;
-		content += `> **sha256** \`${blockSha256}\`\n\n`;
+		content += `**Block \`${block.uuid}\` sha256:** \`${blockSha256}\`\n\n`;
 	}
 
 	content += `Please review whether:\n`;

--- a/cli/commands/crawl.ts
+++ b/cli/commands/crawl.ts
@@ -208,7 +208,6 @@ export function getChangedBlocks(
 		const oldMatch = oldBlocks.find((b) => b.uuid === newBlock.uuid);
 		if (!oldMatch) continue;
 
-		
 		const oldContent = extractBlockContent(oldLines, oldMatch.startLine, oldMatch.endLine);
 		const newContent = extractBlockContent(newLines, newBlock.startLine, newBlock.endLine);
 
@@ -224,8 +223,8 @@ export function getChangedBlocks(
  * Extract the content between @lulaStart and @lulaEnd
  *
  * @param lines The array of lines.
- * @param startLine The line number of @lulaStart 
- * @param endLine The line number of @lulaEnd 
+ * @param startLine The line number of @lulaStart
+ * @param endLine The line number of @lulaEnd
  * @returns The content between the annotations as a string.
  */
 function extractBlockContent(lines: string[], startLine: number, endLine: number): string {

--- a/cli/commands/crawl.ts
+++ b/cli/commands/crawl.ts
@@ -381,7 +381,7 @@ export function generateChangedBlocksContent(
 	for (const block of changedBlocks) {
 		const newBlockText = newText.split('\n').slice(block.startLine, block.endLine).join('\n');
 		const blockSha256 = createHash('sha256').update(newBlockText).digest('hex');
-		content += `**Block \`${block.uuid}\` sha256:** \`${blockSha256}\`\n\n`;
+		content += `**UUID:** \`${block.uuid}\`\n**sha256:** \`${blockSha256}\`\n\n`;
 	}
 
 	return content;
@@ -417,7 +417,7 @@ export function generateRemovedBlocksContent(
 	for (const block of removedBlocks) {
 		const oldBlockText = oldText.split('\n').slice(block.startLine, block.endLine).join('\n');
 		const blockSha256 = createHash('sha256').update(oldBlockText).digest('hex');
-		content += `**Block \`${block.uuid}\` sha256:** \`${blockSha256}\`\n\n`;
+		content += `**UUID:** \`${block.uuid}\`\n**sha256:** \`${blockSha256}\`\n\n`;
 	}
 
 	content += `Please review whether:\n`;

--- a/integration/crawl.test.ts
+++ b/integration/crawl.test.ts
@@ -130,7 +130,7 @@ describe('crawl', () => {
       expect(body).toMatch(/`20–31`/);
       expect(body).toMatch(/`1–5`/);
 
-      expect(body).toMatch(/\*\*Block\*\* \`[-a-f0-9]{36}\`/);
+      expect(body).toMatch(/\*\*UUID:\*\* \`[-a-f0-9]{36}\`/);
       expect(body).toMatch(/\*\*sha256:\*\* \`[a-f0-9]{64}\`/);
 
       const commentTime = new Date(c.created_at);

--- a/integration/crawl.test.ts
+++ b/integration/crawl.test.ts
@@ -60,7 +60,7 @@ describe('crawl', () => {
     }
   }, 120000);
 
-  it("should console log the Lula overview, table with lines changed, uuid and sha256", { timeout: 2 * 60 * 1000 }, () => {
+  it("should console log the Lula overview, table with lines changed, uuid and sha256sum when content changes between annotations", { timeout: 2 * 60 * 1000 }, () => {
     if (!command_output || command_output.length === 0) {
       throw new Error('No command output received - the crawl command may have failed or produced no output');
     }
@@ -103,11 +103,16 @@ describe('crawl', () => {
       }
     );
 
-    // Track created comments for cleanup and filter for our run
-    const relevantComments = comments.filter(comment => {
+    interface IssueComment {
+      id: number;
+      created_at: string;
+      body: string;
+      [key: string]: unknown;
+    }
+
+    const relevantComments: IssueComment[] = (comments as IssueComment[]).filter((comment: IssueComment) => {
       comment_ids.push(comment.id);
-      const created = new Date(comment.created_at);
-      // Look for the new Lula overview header
+      const created: Date = new Date(comment.created_at);
       return created >= testStartTime && comment.body.includes("## Lula Compliance Overview");
     });
 
@@ -116,22 +121,18 @@ describe('crawl', () => {
     for (const c of relevantComments) {
       const body = c.body;
 
-      // New structure checks
       expect(body).toContain("## Lula Compliance Overview");
       expect(body).toContain("Please review the changes to ensure they meet compliance standards.");
       expect(body).toMatch(/\| File \| Lines Changed \|\s*\n\| ---- \| ------------- \|/);
 
-      // Filenames & ranges
       expect(body).toContain("`integration/test-files/ex.ts`");
       expect(body).toContain("`integration/test-files/ex.yaml`");
       expect(body).toMatch(/`20–31`/);
       expect(body).toMatch(/`1–5`/);
 
-      // uuid + sha256 lines (format used in crawl.ts)
       expect(body).toMatch(/> \*\*uuid\*\*-\`[-a-f0-9]{36}\`/);
       expect(body).toMatch(/\*\*sha256\*\* \`[a-f0-9]{64}\`/);
 
-      // Still enforce a reasonable creation window (allowing some slack)
       const commentTime = new Date(c.created_at);
       const secs = (commentTime.getTime() - testStartTime.getTime()) / 1000;
       expect(secs).toBeLessThanOrEqual(60);
@@ -139,6 +140,132 @@ describe('crawl', () => {
     }
 
     console.log(`Found ${relevantComments.length} relevant comments created by this test`);
+  });
+
+  it('should detect when @lulaStart/@lulaEnd annotations are DELETED from an existing file', { timeout: 2 * 60 * 1000 }, async () => {
+    // Test scenario: A file exists with Lula annotations, then the annotations are removed but file remains
+    
+    // Create a mock scenario by testing the getRemovedBlocks function directly
+    const { getRemovedBlocks } = await import('../cli/commands/crawl.js');
+    
+    const uuid = '123e4567-e89b-12d3-a456-426614174000';
+    
+    const oldFileContent = [
+      'function example() {',
+      `  // @lulaStart ${uuid}`,
+      '  const data = "sensitive info";',
+      '  return data;',
+      `  // @lulaEnd ${uuid}`,
+      '}'
+    ].join('\n');
+    
+    const newFileContent = [
+      'function example() {',
+      '  const data = "sensitive info";',
+      '  return data;',
+      '}'
+    ].join('\n');
+    
+    const removedBlocks = getRemovedBlocks(oldFileContent, newFileContent);
+    
+    expect(removedBlocks).toHaveLength(1);
+    expect(removedBlocks[0].uuid).toBe(uuid);
+    expect(removedBlocks[0].startLine).toBe(1); // @lulaStart line
+    expect(removedBlocks[0].endLine).toBe(5); // @lulaEnd line + 1
+  });
+
+  it('should detect when a whole file with annotations is DELETED', { timeout: 2 * 60 * 1000 }, async () => {
+    // Test scenario: An entire file containing Lula annotations is deleted
+    
+    const { containsLulaAnnotations, analyzeDeletedFiles } = await import('../cli/commands/crawl.js');
+    
+    // Test the containsLulaAnnotations function
+    const fileWithAnnotations = [
+      'const config = {',
+      '  // @lulaStart 123e4567-e89b-12d3-a456-426614174000',
+      '  apiKey: "secret-key",',
+      '  // @lulaEnd 123e4567-e89b-12d3-a456-426614174000',
+      '};'
+    ].join('\n');
+    
+    const fileWithoutAnnotations = [
+      'const config = {',
+      '  apiKey: "secret-key",',
+      '};'
+    ].join('\n');
+    
+    expect(containsLulaAnnotations(fileWithAnnotations)).toBe(true);
+    expect(containsLulaAnnotations(fileWithoutAnnotations)).toBe(false);
+    
+    // Test with partial annotations (should still detect)
+    const fileWithOnlyStart = [
+      'const config = {',
+      '  // @lulaStart 123e4567-e89b-12d3-a456-426614174000',
+      '  apiKey: "secret-key",',
+      '};'
+    ].join('\n');
+    
+    const fileWithOnlyEnd = [
+      'const config = {',
+      '  apiKey: "secret-key",',
+      '  // @lulaEnd 123e4567-e89b-12d3-a456-426614174000',
+      '};'
+    ].join('\n');
+    
+    expect(containsLulaAnnotations(fileWithOnlyStart)).toBe(true);
+    expect(containsLulaAnnotations(fileWithOnlyEnd)).toBe(true);
+  });
+
+  it('should NOT detect changes when content above annotations changes but annotation content is unchanged', { timeout: 2 * 60 * 1000 }, async () => {
+    // Test scenario: Lines are added/changed above the UUID block, but content between markers is identical
+    
+    const { getChangedBlocks } = await import('../cli/commands/crawl.js');
+    
+    const uuid = '123e4567-e89b-12d3-a456-426614174000';
+    
+    const originalFile = [
+      'function example() {',
+      '  console.log("original header");',
+      `  // @lulaStart ${uuid}`,
+      '  const sensitiveData = "unchanged content";',
+      '  return sensitiveData;',
+      `  // @lulaEnd ${uuid}`,
+      '}'
+    ].join('\n');
+    
+    const modifiedFileWithChangesAbove = [
+      'function example() {',
+      '  console.log("MODIFIED header");', // This line changed
+      '  const newVariable = "added";',    // This line added
+      `  // @lulaStart ${uuid}`,
+      '  const sensitiveData = "unchanged content";', // Content between markers is identical
+      '  return sensitiveData;',                      // Content between markers is identical
+      `  // @lulaEnd ${uuid}`,
+      '}'
+    ].join('\n');
+    
+    const changedBlocks = getChangedBlocks(originalFile, modifiedFileWithChangesAbove);
+    
+    // Should be 0 because content between @lulaStart and @lulaEnd is identical
+    expect(changedBlocks).toHaveLength(0);
+    
+    // Test the opposite case: content between markers actually changes
+    const modifiedFileWithChangesInside = [
+      'function example() {',
+      '  console.log("MODIFIED header");', 
+      '  const newVariable = "added";',    
+      `  // @lulaStart ${uuid}`,
+      '  const sensitiveData = "CHANGED content";', // This line changed inside the block
+      '  return sensitiveData;',                    
+      `  // @lulaEnd ${uuid}`,
+      '}'
+    ].join('\n');
+    
+    const changedBlocksInside = getChangedBlocks(originalFile, modifiedFileWithChangesInside);
+    
+    // Should be 1 because content between @lulaStart and @lulaEnd actually changed
+    expect(changedBlocksInside).toHaveLength(1);
+    expect(changedBlocksInside[0].uuid).toBe(uuid);
   });
 });
 


### PR DESCRIPTION
## Description

The crawl command was considering line numbers when testing if the code has changed between annotations. We should only consider the lines between the annotations.

The other fix is around the comment rendering, here is a [PEXEX PR](https://github.com/defenseunicorns/pepr-excellent-examples/pull/394) running the lula nightly version.

## Related Issue

Fixes #296 
Fixes #297 

<!-- or -->

Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed
