### PR TITLE
fix: fixes around nist 800 rev 5 controls

### DIFF
--- a/cli/server/infrastructure/fileStore.test.ts
+++ b/cli/server/infrastructure/fileStore.test.ts
@@ -369,7 +369,7 @@ control_id_field: id`;
 			expect(content).toContain('test-uuid-2');
 		});
 
-		it('should update existing mapping with same UUID', async () => {
+		it('should save a new mapping - to update we delete and create based on the hash', async () => {
 			const mapping: Partial<Mapping> = {
 				uuid: 'test-uuid-1',
 				control_id: 'AC-1',
@@ -394,7 +394,7 @@ control_id_field: id`;
 			const content = readFileSync(expectedPath, 'utf8');
 			expect(content).toContain('Updated mapping');
 			expect(content).toContain('implemented');
-			expect(content).not.toContain('Original mapping');
+			expect(content).toContain('Original mapping');
 		});
 	});
 

--- a/cli/server/infrastructure/fileStore.test.ts
+++ b/cli/server/infrastructure/fileStore.test.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The Lula Authors
 
+import { createHash } from 'crypto';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -346,7 +347,8 @@ control_id_field: id`;
 				control_id: 'AC-1',
 				justification: 'First mapping',
 				source_entries: [],
-				status: 'planned'
+				status: 'planned',
+				hash: 'abc123'
 			};
 
 			const mapping2: Partial<Mapping> = {
@@ -354,7 +356,8 @@ control_id_field: id`;
 				control_id: 'AC-1',
 				justification: 'Second mapping',
 				source_entries: [],
-				status: 'planned'
+				status: 'planned',
+				hash: 'abc1234'
 			};
 
 			await fileStore.saveMapping(mapping1 as Mapping);
@@ -421,8 +424,11 @@ control_id_field: id`;
 				}
 			];
 
+			// Add hashes to mappings before saving
 			for (const mapping of mappings) {
-				await fileStore.saveMapping(mapping as Mapping);
+				const mappingWithHash = mapping as Mapping;
+				mappingWithHash.hash = createHash('sha256').update(JSON.stringify(mapping)).digest('hex');
+				await fileStore.saveMapping(mappingWithHash);
 			}
 		});
 
@@ -467,37 +473,52 @@ control_id_field: id`;
 		beforeEach(async () => {
 			const mappings: Partial<Mapping>[] = [
 				{
-					uuid: 'uuid-1',
+					uuid: 'delete-test-1',
 					control_id: 'AC-1',
-					justification: 'Mapping 1',
+					justification: 'Delete Test 1',
 					source_entries: [],
 					status: 'planned'
 				},
 				{
-					uuid: 'uuid-2',
+					uuid: 'delete-test-2',
 					control_id: 'AC-1',
-					justification: 'Mapping 2',
+					justification: 'Delete Test 2',
 					source_entries: [],
 					status: 'planned'
 				}
 			];
 
+			// Add hashes to mappings before saving
 			for (const mapping of mappings) {
-				await fileStore.saveMapping(mapping as Mapping);
+				const mappingWithHash = mapping as Mapping;
+				mappingWithHash.hash = createHash('sha256').update(JSON.stringify(mapping)).digest('hex');
+				await fileStore.saveMapping(mappingWithHash);
 			}
 		});
 
 		it('should delete a specific mapping by UUID', async () => {
-			await fileStore.deleteMapping('AC-1:uuid-1');
+			// First load mappings to get the hash
+			const allMappings = await fileStore.loadMappings();
+			const testMapping = allMappings.find((m) => m.uuid === 'delete-test-1');
+			expect(testMapping).toBeDefined();
+
+			await fileStore.deleteMapping(`AC-1:${testMapping!.hash}`);
 
 			const mappings = await fileStore.loadMappings();
-			expect(mappings).toHaveLength(1);
-			expect(mappings[0].uuid).toBe('uuid-2');
+			expect(mappings.find((m) => m.uuid === 'delete-test-1')).toBeUndefined();
+			expect(mappings.find((m) => m.uuid === 'delete-test-2')).toBeDefined();
 		});
 
 		it('should delete the entire file when no mappings remain', async () => {
-			await fileStore.deleteMapping('AC-1:uuid-1');
-			await fileStore.deleteMapping('AC-1:uuid-2');
+			// Load mappings to get their hashes
+			const allMappings = await fileStore.loadMappings();
+			const mapping1 = allMappings.find((m) => m.uuid === 'delete-test-1');
+			const mapping2 = allMappings.find((m) => m.uuid === 'delete-test-2');
+			expect(mapping1).toBeDefined();
+			expect(mapping2).toBeDefined();
+
+			await fileStore.deleteMapping(`AC-1:${mapping1!.hash}`);
+			await fileStore.deleteMapping(`AC-1:${mapping2!.hash}`);
 
 			const expectedPath = join(tempDir, 'mappings', 'AC', 'AC-1-mappings.yaml');
 			expect(existsSync(expectedPath)).toBe(false);

--- a/cli/server/infrastructure/fileStore.ts
+++ b/cli/server/infrastructure/fileStore.ts
@@ -444,9 +444,7 @@ export class FileStore {
 
 					if (Array.isArray(parsed)) {
 						parsed.forEach((mapping) => {
-							console.log('Load Mapping: ' + JSON.stringify(mapping));
 							mapping.hash = createHash('sha256').update(JSON.stringify(mapping)).digest('hex');
-							console.log('Load  Hash: ' + mapping.hash);
 							return mapping;
 						});
 						mappings.push(...parsed);
@@ -496,13 +494,7 @@ export class FileStore {
 		const cleanMapping = { ...mapping };
 		delete cleanMapping.hash;
 
-		// Update or add the mapping
-		const existingIndex = existingMappings.findIndex((m) => m.hash === mapping.hash);
-		if (existingIndex >= 0) {
-			existingMappings[existingIndex] = cleanMapping;
-		} else {
-			existingMappings.push(cleanMapping);
-		}
+		existingMappings.push(cleanMapping);
 
 		// Save back to file
 		try {
@@ -535,10 +527,8 @@ export class FileStore {
 				const originalLength = mappings.length;
 				// we need to re-calculate the hash
 				mappings = mappings.filter((m) => {
-					console.log('Delete Mapping: ' + JSON.stringify(m));
-					m.hash = createHash('sha256').update(JSON.stringify(m)).digest('hex');
-					console.log('Delete  Hash: ' + m.hash);
-					return `${m.control_id}:${m.hash}` !== compositeKey;
+					const hash = createHash('sha256').update(JSON.stringify(m)).digest('hex');
+					return `${m.control_id}:${hash}` !== compositeKey;
 				});
 
 				// If we removed a mapping, save the file
@@ -547,14 +537,8 @@ export class FileStore {
 						// Delete the file if no mappings remain
 						unlinkSync(file);
 					} else {
-						// Strip hash fields before saving
-						const cleanMappings = mappings.map((m) => {
-							const clean = { ...m };
-							delete clean.hash;
-							return clean;
-						});
 						// Save the remaining mappings
-						const yamlContent = yaml.dump(cleanMappings, {
+						const yamlContent = yaml.dump(mappings, {
 							indent: 2,
 							lineWidth: -1,
 							noRefs: true

--- a/cli/server/server.test.ts
+++ b/cli/server/server.test.ts
@@ -10,10 +10,12 @@ type RouteHandler = (
 	res: { sendFile: (file: string, opts: { root: string }) => void }
 ) => void;
 type GetRoute = (path: string, handler: RouteHandler) => void;
+type PostRoute = (path: string, handler: RouteHandler) => void;
 
 type ExpressAppMock = {
 	use: UseMiddleware;
 	get: GetRoute;
+	post: PostRoute;
 };
 
 type ExpressFactory = (() => ExpressAppMock) & {
@@ -39,6 +41,7 @@ const h = vi.hoisted(() => {
 
 		expressUse: vi.fn<UseMiddleware>(),
 		expressGet: vi.fn<GetRoute>(),
+		expressPost: vi.fn<PostRoute>(),
 		expressJson: vi.fn<(opts: { limit: string }) => unknown>(),
 		expressStatic: vi.fn<(dir: string) => unknown>(),
 
@@ -74,7 +77,7 @@ vi.mock('fs', async (importOriginal) => {
 });
 
 vi.mock('express', () => {
-	const app: ExpressAppMock = { use: h.expressUse, get: h.expressGet };
+	const app: ExpressAppMock = { use: h.expressUse, get: h.expressGet, post: h.expressPost };
 
 	const expressFn = vi.fn(() => app) as unknown as ExpressFactory;
 

--- a/cli/server/server.ts
+++ b/cli/server/server.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'url';
 import { initializeServerState, loadAllData, saveMappingsToFile } from './serverState';
 import spreadsheetRoutes from './spreadsheetRoutes';
 import { wsManager } from './websocketServer';
+import { createHash } from 'crypto';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -58,6 +59,13 @@ export async function createServer(options: ServerOptions): Promise<{
 	// Serve frontend for all other routes (SPA fallback)
 	app.get('/*splat', (req, res) => {
 		res.sendFile('index.html', { root: distPath });
+	});
+
+	// Frontend cannot create hash - webcrypto hash is not supported in all browsers
+	app.post('/hash', (req, res) => {
+		delete req.body.hash;
+		const hash = createHash('sha256').update(JSON.stringify(req.body)).digest('hex');
+		res.status(200).json({ hash });
 	});
 
 	// Create HTTP server for both Express and WebSocket

--- a/cli/server/websocketServer.ts
+++ b/cli/server/websocketServer.ts
@@ -205,52 +205,6 @@ class WebSocketManager {
 					break;
 				}
 
-				case 'update-mapping': {
-					// Update an existing mapping
-					const state = getServerState();
-					if (payload && payload.hash) {
-						const mapping = payload as unknown as Mapping;
-
-						// Save the mapping (files still use original UUID-based approach)
-						await state.fileStore.saveMapping(mapping);
-
-						// Find and remove old cache entry first
-						let oldCompositeKey = '';
-						for (const [key, value] of state.mappingsCache.entries()) {
-							console.log('Checking mapping in cache:', key);
-							if (value.hash === mapping.hash) {
-								oldCompositeKey = key;
-								break;
-							}
-						}
-						if (oldCompositeKey) {
-							state.mappingsCache.delete(oldCompositeKey);
-						}
-
-						// Add updated mapping with new checksum-based key
-						console.log(`${JSON.stringify(mapping)}`);
-						const mappingCheckSum = crypto
-							.createHash('sha256')
-							.update(JSON.stringify(mapping))
-							.digest('hex');
-						mapping.hash = mappingCheckSum;
-						const compositeKey = `${mapping.control_id}:${mappingCheckSum}`;
-						state.mappingsCache.set(compositeKey, mapping);
-
-						// Send success response
-						ws.send(
-							JSON.stringify({
-								type: 'mapping-updated',
-								payload: { uuid: mapping.uuid, success: true }
-							})
-						);
-
-						// Broadcast the updated state to all clients
-						this.broadcastState();
-					}
-					break;
-				}
-
 				case 'delete-mapping': {
 					// Delete a mapping
 					const state = getServerState();

--- a/src/lib/components/controls/MappingCard.svelte
+++ b/src/lib/components/controls/MappingCard.svelte
@@ -23,8 +23,8 @@
 	}
 
 	function handleDelete() {
-		if (confirm('Are you sure you want to delete this mapping?'+ mapping.uuid  + '')) {
-			onDelete?.(mapping.hash || '');
+		if (confirm('Are you sure you want to delete this mapping? '+ mapping.uuid)) {
+			onDelete?.(mapping.hash!);
 		}
 	}
 </script>

--- a/src/lib/components/controls/MappingCard.svelte
+++ b/src/lib/components/controls/MappingCard.svelte
@@ -8,7 +8,7 @@
 	interface Props {
 		mapping: Mapping;
 		onEdit?: (mapping: Mapping) => void;
-		onDelete?: (uuid: string) => void;
+		onDelete?: (hash: string) => void;
 		showActions?: boolean;
 	}
 
@@ -23,8 +23,8 @@
 	}
 
 	function handleDelete() {
-		if (confirm('Are you sure you want to delete this mapping?')) {
-			onDelete?.(mapping.uuid);
+		if (confirm('Are you sure you want to delete this mapping?'+ mapping.uuid  + '')) {
+			onDelete?.(mapping.hash || '');
 		}
 	}
 </script>

--- a/src/lib/components/controls/tabs/MappingsTab.svelte
+++ b/src/lib/components/controls/tabs/MappingsTab.svelte
@@ -91,9 +91,8 @@
 				status: data.status,
 				source_entries: data.source_entries,
 			};
-
 			// hashes change every time so we just delete an create
-			await wsClient.deleteMapping(editingMapping.hash!);
+			await wsClient.deleteMapping(`${editingMapping.control_id}:${editingMapping.hash!}`);
 			delete updatedMapping.hash;
 			await wsClient.createMapping(updatedMapping);
 
@@ -113,7 +112,7 @@
 
 		try {
 			// Backend expects UUID for file operations
-			await wsClient.deleteMapping(mappingToDelete.hash!);
+			await wsClient.deleteMapping(`${mappingToDelete.control_id}:${mappingToDelete.hash!}`);
 		} catch (error) {
 			console.error('Failed to delete mapping:', error);
 		}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -36,6 +36,8 @@ export interface Mapping {
 	justification: string;
 	source_entries: SourceEntry[];
 	status: 'planned' | 'implemented' | 'verified';
+	cci?: string;
+	hash?: string;
 	created_by?: string;
 }
 

--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -355,10 +355,6 @@ class WebSocketClient {
 		return this.sendCommand('create-mapping', mapping);
 	}
 
-	async updateMapping(mapping: Mapping) {
-		return this.sendCommand('update-mapping', mapping);
-	}
-
 	async deleteMapping(composite_key: string) {
 		return this.sendCommand('delete-mapping', { composite_key });
 	}

--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -359,8 +359,8 @@ class WebSocketClient {
 		return this.sendCommand('update-mapping', mapping);
 	}
 
-	async deleteMapping(hash: string) {
-		return this.sendCommand('delete-mapping', { hash });
+	async deleteMapping(composite_key: string) {
+		return this.sendCommand('delete-mapping', { composite_key });
 	}
 
 	async switchControlSet(path: string) {

--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -359,8 +359,8 @@ class WebSocketClient {
 		return this.sendCommand('update-mapping', mapping);
 	}
 
-	async deleteMapping(uuid: string) {
-		return this.sendCommand('delete-mapping', { uuid });
+	async deleteMapping(hash: string) {
+		return this.sendCommand('delete-mapping', { hash });
 	}
 
 	async switchControlSet(path: string) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,11 @@ export default defineConfig({
 				target: 'http://localhost:3000',
 				changeOrigin: true,
 				secure: false
+			},
+			'/hash': {
+				target: 'http://localhost:3000',
+				changeOrigin: true,
+				secure: false
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Fixes around shared UUID that came up when we migrated from NIST 800 Rev 4 to NIST 800 Rev 5. This PR changes the way that the mappings are held in ephemeral memory to allow the Lula UI to display mappings that share UUID and `control_id`

Notable Changes:
- The ephemeral state (for mappings), mainly `map[string]interface{}` uses a new key, hash, which is the sha256sum of the mapping.
- The checksums must be created on the backend. There is webcrypto but it is not supported in all browsers
- There was a general agreement not to create any breaking changes, ie, the mappings can remain as it and when being read from the filesystem the hash will be generated.

## Related Issue

Fixes #340 

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed
