### PR TITLE
feat: multiple cci per mapping and custom multiselect

### DIFF
--- a/src/lib/components/controls/MappingCard.svelte
+++ b/src/lib/components/controls/MappingCard.svelte
@@ -27,6 +27,7 @@
 			onDelete?.(mapping.hash!);
 		}
 	}
+
 </script>
 
 <div
@@ -75,7 +76,11 @@
 		<p class="text-sm text-gray-700 dark:text-gray-300 leading-relaxed mb-4">
 			{mapping.justification}
 		</p>
-		
+		{#if mapping.cci}
+			<div class="mb-4">
+				<h4 class="text-xs font-semibold text-gray-600 dark:text-gray-400 tracking-wider mb-2">CCIs:<span class="text-xs font-mono  text-gray-500 dark:text-gray-300 ml-2 break-all" title="CCis">{mapping.cci}</span></h4>
+			</div>
+		{/if}
 		{#if mapping.source_entries && mapping.source_entries.length > 0}
 			<div class="mb-4">
 				<h4 class="text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider mb-2">Source References</h4>

--- a/src/lib/components/controls/MappingCard.svelte
+++ b/src/lib/components/controls/MappingCard.svelte
@@ -78,7 +78,7 @@
 		</p>
 		{#if mapping.cci}
 			<div class="mb-4">
-				<h4 class="text-xs font-semibold text-gray-600 dark:text-gray-400 tracking-wider mb-2">CCIs:<span class="text-xs font-mono  text-gray-500 dark:text-gray-300 ml-2 break-all" title="CCis">{mapping.cci}</span></h4>
+				<h4 class="text-xs font-semibold text-gray-600 dark:text-gray-400 tracking-wider mb-2">CCIs:<span class="text-xs font-mono  text-gray-500 dark:text-gray-300 ml-2 break-all" title="CCIs">{mapping.cci}</span></h4>
 			</div>
 		{/if}
 		{#if mapping.source_entries && mapping.source_entries.length > 0}

--- a/src/lib/components/controls/MappingForm.svelte
+++ b/src/lib/components/controls/MappingForm.svelte
@@ -129,7 +129,7 @@
 			<FormField
 				id="mapping-cci"
 				label="Mapping CCI(s)"
-				type="multi-select"
+				type="multiselect"
 				bind:value={selectedCCIs}
 				options={cciOptions}
 			/>

--- a/src/lib/components/controls/MappingForm.svelte
+++ b/src/lib/components/controls/MappingForm.svelte
@@ -55,7 +55,7 @@
 	);
 
 	
-	let selectedCCIs = $state<string[]>(
+	let selectedCCIs = $derived(
 		(formData.cci ?? '')
 			.split(';')
 			.map((s) => s.trim())

--- a/src/lib/components/controls/MappingForm.svelte
+++ b/src/lib/components/controls/MappingForm.svelte
@@ -133,7 +133,6 @@
 				bind:value={selectedCCIs}
 				options={cciOptions}
 			/>
-			<!-- <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Selected: {formData.cci}</p> -->
 			{/if}
 
 			<FormField

--- a/src/lib/components/controls/MappingForm.svelte
+++ b/src/lib/components/controls/MappingForm.svelte
@@ -11,6 +11,7 @@
 		justification: string;
 		status: 'planned' | 'implemented' | 'verified';
 		source_entries: SourceEntry[];
+		cci: string;
 	}
 
 	interface Props {
@@ -19,6 +20,7 @@
 		onCancel: () => void;
 		loading?: boolean;
 		submitLabel?: string;
+		cci?: string;
 	}
 
 	let {
@@ -26,14 +28,16 @@
 		onSubmit,
 		onCancel,
 		loading = false,
-		submitLabel = 'Create Mapping'
+		submitLabel = 'Create Mapping',
+		cci
 	}: Props = $props();
 
 	let formData = $state<MappingFormData>({
 		uuid: initialData.uuid || '',
 		justification: initialData.justification || '',
 		status: initialData.status || 'planned',
-		source_entries: initialData.source_entries || []
+		source_entries: initialData.source_entries || [],
+		cci: initialData.cci ?? ''
 	});
 	
 	let newLocation = $state('');
@@ -42,6 +46,25 @@
 	const statusOptions = ['planned', 'implemented', 'verified'];
 
 	const isValid = $derived(formData.justification.trim().length > 0);
+	
+	const cciOptions = $derived(
+		(cci ?? '')
+			.split(';')
+			.map((s) => s.trim())
+			.filter(Boolean)
+	);
+
+	
+	let selectedCCIs = $state<string[]>(
+		(formData.cci ?? '')
+			.split(';')
+			.map((s) => s.trim())
+			.filter(Boolean)
+	);
+
+	$effect(() => {
+		formData.cci = selectedCCIs.join('; ');
+	});
 
 	function handleSubmit() {
 		if (!isValid || loading) return;
@@ -54,7 +77,8 @@
 			uuid: initialData.uuid || '',
 			justification: initialData.justification || '',
 			status: initialData.status || 'planned',
-			source_entries: initialData.source_entries || []
+			source_entries: initialData.source_entries || [],
+			cci: initialData.cci ?? ''
 		};
 		newLocation = '';
 		newShasum = '';
@@ -101,6 +125,16 @@
 				placeholder="Explain how this compliance artifact satisfies the control requirements..."
 				required
 			/>
+			{#if cci}
+			<FormField
+				id="mapping-cci"
+				label="Mapping CCI(s)"
+				type="multi-select"
+				bind:value={selectedCCIs}
+				options={cciOptions}
+			/>
+			<!-- <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Selected: {formData.cci}</p> -->
+			{/if}
 
 			<FormField
 				id="mapping-status"

--- a/src/lib/components/controls/renderers/EditableFieldRenderer.svelte
+++ b/src/lib/components/controls/renderers/EditableFieldRenderer.svelte
@@ -42,6 +42,63 @@
 				<option value={option}>{option}</option>
 			{/each}
 		</select>
+	{:else if field.ui_type === 'multiselect' && field.options}
+			{@const currentValues = Array.isArray(value) ? (value as string[]) : []}
+
+		<div id={fieldId} class="flex flex-wrap gap-2">
+			{#each field.options as option (option)}
+				{@const selected = currentValues.includes(option)}
+
+				<label
+					class={`inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border text-sm cursor-pointer transition-colors
+						focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2
+						dark:focus-within:ring-offset-gray-900
+						${
+							selected
+								? 'bg-blue-50 border-blue-500 text-blue-700 dark:bg-blue-900/40 dark:border-blue-400 dark:text-blue-100'
+								: 'bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-200'
+						}
+						${!field.editable ? 'opacity-50 cursor-not-allowed' : ''}
+					`}
+				>
+					<input
+						type="checkbox"
+						value={option}
+						checked={selected}
+						disabled={!field.editable}
+						onchange={(e: Event) => {
+							const input = e.currentTarget as HTMLInputElement;
+							const current = Array.isArray(value) ? (value as string[]) : [];
+							let updated: string[];
+
+							if (input.checked) {
+								updated = current.includes(option) ? current : [...current, option];
+							} else {
+								updated = current.filter((v) => v !== option);
+							}
+
+							value = updated;
+							onChange();
+						}}
+						class="sr-only"
+					/>
+
+					<span
+						class={`inline-flex items-center justify-center w-4 h-4 rounded border text-[10px] font-bold
+							${
+								selected
+									? 'border-blue-500 bg-blue-500 text-white'
+									: 'border-gray-400 bg-transparent text-transparent'
+							}
+						`}
+					>
+						✓
+					</span>
+
+					<span>{option}</span>
+				</label>
+			{/each}
+		</div>
 	{:else if field.ui_type === 'textarea' || field.ui_type === 'long_text'}
 		<textarea
 			id={fieldId}

--- a/src/lib/components/controls/tabs/CustomFieldsTab.svelte
+++ b/src/lib/components/controls/tabs/CustomFieldsTab.svelte
@@ -49,6 +49,7 @@
 		// Dropdowns and short fields can be side by side
 		if (
 			field.ui_type === 'select' ||
+			field.ui_type === 'multiselect' ||
 			field.ui_type === 'boolean' ||
 			field.ui_type === 'date' ||
 			field.ui_type === 'number' ||

--- a/src/lib/components/controls/tabs/ImplementationTab.svelte
+++ b/src/lib/components/controls/tabs/ImplementationTab.svelte
@@ -48,6 +48,7 @@
 		// Dropdowns and short fields can be side by side
 		if (
 			field.ui_type === 'select' ||
+			field.ui_type === 'multiselect' ||
 			field.ui_type === 'boolean' ||
 			field.ui_type === 'date' ||
 			field.ui_type === 'number' ||

--- a/src/lib/components/controls/tabs/OverviewTab.svelte
+++ b/src/lib/components/controls/tabs/OverviewTab.svelte
@@ -53,6 +53,7 @@
 		// Dropdowns and short fields can be side by side
 		if (
 			field.ui_type === 'select' ||
+			field.ui_type === 'multiselect' ||
 			field.ui_type === 'boolean' ||
 			field.ui_type === 'date' ||
 			field.ui_type === 'number' ||

--- a/src/lib/components/forms/FormField.svelte
+++ b/src/lib/components/forms/FormField.svelte
@@ -5,7 +5,7 @@
 	interface BaseProps {
 		id: string;
 		label: string;
-		type?: 'text' | 'textarea' | 'select' | 'multi-select';
+		type?: 'text' | 'textarea' | 'select' | 'multiselect';
 		options?: string[];
 		rows?: number;
 		placeholder?: string;
@@ -20,7 +20,7 @@
 	}
 
 	interface MultiSelectProps extends BaseProps {
-		type: 'multi-select';
+		type: 'multiselect';
 		value: string[];
 	}
 
@@ -66,7 +66,7 @@
 				</div>
 			{/if}
 		</div>
-	{:else if type === 'multi-select' && options.length > 0}
+	{:else if type === 'multiselect' && options.length > 0}
 		<div class="flex flex-wrap gap-2">
 			{#each options as option (option)}
 				{@const selected = (value as string[]).includes(option)}

--- a/src/lib/components/forms/FormField.svelte
+++ b/src/lib/components/forms/FormField.svelte
@@ -2,11 +2,10 @@
 <!-- SPDX-FileCopyrightText: 2023-Present The Lula Authors -->
 
 <script lang="ts">
-	interface Props {
+	interface BaseProps {
 		id: string;
 		label: string;
-		type?: 'text' | 'textarea' | 'select';
-		value: string;
+		type?: 'text' | 'textarea' | 'select' | 'multi-select';
 		options?: string[];
 		rows?: number;
 		placeholder?: string;
@@ -14,6 +13,18 @@
 		error?: string;
 		onChange?: () => void;
 	}
+
+	interface SingleValueProps extends BaseProps {
+		type?: 'text' | 'textarea' | 'select';
+		value: string;
+	}
+
+	interface MultiSelectProps extends BaseProps {
+		type: 'multi-select';
+		value: string[];
+	}
+
+	type Props = SingleValueProps | MultiSelectProps;
 
 	let {
 		id,
@@ -54,6 +65,57 @@
 					{value.length} characters
 				</div>
 			{/if}
+		</div>
+	{:else if type === 'multi-select' && options.length > 0}
+		<div class="flex flex-wrap gap-2">
+			{#each options as option (option)}
+				{@const selected = (value as string[]).includes(option)}
+				<label
+					class={`inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border text-sm cursor-pointer transition-colors
+						focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2
+						dark:focus-within:ring-offset-gray-900
+						${
+							selected
+								? 'bg-blue-50 border-blue-500 text-blue-700 dark:bg-blue-900/40 dark:border-blue-400 dark:text-blue-100'
+								: 'bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-200'
+						}
+						${error ? 'border-red-400' : ''}
+					`}
+				>
+					<input
+						type="checkbox"
+						value={option}
+						checked={selected}
+						onchange={(e: Event) => {
+							const input = e.currentTarget as HTMLInputElement;
+							const current = value as string[];
+
+							if (input.checked) {
+								value = current.includes(option) ? current : [...current, option];
+							} else {
+								value = current.filter((v) => v !== option);
+							}
+
+							onChange?.();
+						}}
+						class="sr-only"
+					/>
+
+					<span
+						class={`inline-flex items-center justify-center w-4 h-4 rounded border text-[10px] font-bold
+							${
+								selected
+									? 'border-blue-500 bg-blue-500 text-white'
+									: 'border-gray-400 bg-transparent text-transparent'
+							}
+						`}
+					>
+						✓
+					</span>
+
+					<span>{option}</span>
+				</label>
+			{/each}
 		</div>
 	{:else if type === 'select' && options.length > 0}
 		<div class="relative">

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -72,7 +72,8 @@ export interface FieldSchema {
 		| 'date'
 		| 'number'
 		| 'boolean'
-		| 'long_text';
+		| 'long_text'
+		| 'multiselect';
 	is_array: boolean;
 	max_length?: number;
 	usage_count?: number;

--- a/src/routes/control/[id]/+page.svelte
+++ b/src/routes/control/[id]/+page.svelte
@@ -3,7 +3,7 @@
 
 <script lang="ts">
 	import { goto } from '$app/navigation';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import { ControlDetailsPanel, ControlsList } from '$components/controls';
 	import { wsClient } from '$lib/websocket';
 	import { selectedControl } from '$stores/compliance';
@@ -16,7 +16,7 @@
 
 	// React to URL parameter changes and fetch control details
 	$effect(() => {
-		const controlId = $page.params.id;
+		const controlId = page.params.id;
 		if (!controlId) return;
 
 		const decodedControlId = decodeURIComponent(controlId);


### PR DESCRIPTION
## Description

This feature allows multiple CCI per mapping. This came up when looking at NIST 800 Rev 5 noticing that several of the justifications were identical, the output would have duplicated lines, instead, this allows us to combine CCIs into the justifications allowing a "merging" of mappings.

If the control has a CCI field, then the data from the CCI field will be displayed in the MappingsTab, and eventually written to the `*-mapping.yaml`

## Related Issue

Fixes #341 
Fixes #344 

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New features (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed
