### PR TITLE
fix: update release to node 24.x, npm 11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: '22.20.x'
+          node-version: '24.x'
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 


### PR DESCRIPTION
## Description

[Trusted publishing](https://docs.npmjs.com/trusted-publishers) requires npm 11.5.1+.