### PR TITLE
fix: update cci definitions for separation

### DIFF
--- a/src/lib/components/controls/renderers/FieldRenderer.svelte
+++ b/src/lib/components/controls/renderers/FieldRenderer.svelte
@@ -23,7 +23,7 @@
 		field && 
 		(field.ui_type === 'textarea' || field.ui_type === 'long_text') &&
 		typeof value === 'string' &&
-		value.includes('\n')
+		value.includes('\n') && !value.includes('\n\n\n')
 	);
 </script>
 


### PR DESCRIPTION
## Description

This creates newlines in between CCI strings to make the data more readable in the UI. There is no guarantee on the structure of the CI but we do get the data from the CCI field to see what "string" we need to match on. This is only relevant when there are multiple CCIs and the CCI Definition field becomes hard to read.  

## Related Issue

Fixes #333 

<!-- or -->

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed
