### PR TITLE
fix(ui): prevent scroll jump when toggling CCI checkboxes in mapping

### DIFF
--- a/src/lib/components/controls/MappingForm.svelte
+++ b/src/lib/components/controls/MappingForm.svelte
@@ -54,16 +54,28 @@
 			.filter(Boolean)
 	);
 
-	
-	let selectedCCIs = $derived(
-		(formData.cci ?? '')
+	function parseCciList(value: string | undefined | null): string[] {
+		return (value ?? '')
 			.split(';')
 			.map((s) => s.trim())
-			.filter(Boolean)
-	);
+			.filter(Boolean);
+	}
+	
+	let selectedCCIs = $state<string[]>(parseCciList(formData.cci));
 
 	$effect(() => {
-		formData.cci = selectedCCIs.join('; ');
+		const joined = selectedCCIs.join('; ');
+		if (formData.cci !== joined) {
+			formData.cci = joined;
+		}
+	});
+
+	$effect(() => {
+		const parsed = parseCciList(formData.cci);
+		// Keep the multiselect UI in sync if formData.cci changes externally (reset/edit)
+		if (parsed.join('; ') !== selectedCCIs.join('; ')) {
+			selectedCCIs = parsed;
+		}
 	});
 
 	function handleSubmit() {
@@ -80,6 +92,7 @@
 			source_entries: initialData.source_entries || [],
 			cci: initialData.cci ?? ''
 		};
+		selectedCCIs = parseCciList(formData.cci);
 		newLocation = '';
 		newShasum = '';
 		onCancel();

--- a/src/lib/components/forms/FormField.svelte
+++ b/src/lib/components/forms/FormField.svelte
@@ -71,7 +71,7 @@
 			{#each options as option (option)}
 				{@const selected = (value as string[]).includes(option)}
 				<label
-					class={`inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border text-sm cursor-pointer transition-colors
+					class={`relative inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border text-sm cursor-pointer transition-colors
 						focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2
 						dark:focus-within:ring-offset-gray-900
 						${


### PR DESCRIPTION
## Description
Fixes an issue in the Mappings tab where clicking a CCI checkbox could cause the main pane to jump and become non-scrollable once the mapping form content exceeded the visible height.

### What changed
`src/lib/components/controls/MappingForm.svelte`
Replaced derived CCI selection ($derived) with writable state ($state) so bind:value updates are valid.
Added two-way sync between selectedCCIs (array) and formData.cci (semicolon-delimited string), including reset behavior on cancel.

`src/lib/components/forms/FormField.svelte`
Added relative to the multiselect option <label> so the hidden checkbox (sr-only / absolutely positioned) is positioned within the pill, preventing focus-driven scroll jumps in scrollable containers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed


