### PR TITLE
fix(ui): prevent scroll jump for schema-driven multiselect checkboxes

### DIFF
--- a/src/lib/components/controls/renderers/EditableFieldRenderer.svelte
+++ b/src/lib/components/controls/renderers/EditableFieldRenderer.svelte
@@ -50,7 +50,7 @@
 				{@const selected = currentValues.includes(option)}
 
 				<label
-					class={`inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border text-sm cursor-pointer transition-colors
+					class={`relative inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border text-sm cursor-pointer transition-colors
 						focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2
 						dark:focus-within:ring-offset-gray-900
 						${


### PR DESCRIPTION
## Description
Fixes a UI issue where clicking schema-driven multiselect checkboxes (generated from lula.yaml field schema options like uds-alignment) could cause the main panel to jump and become difficult/non-intuitive to scroll when the right pane is overflow-scrollable.

### What changed
`src/lib/components/controls/renderers/EditableFieldRenderer.svelte`
Added relative to the multiselect option <label> so the hidden checkbox input is positioned within the pill, preventing focus-induced scroll jumps.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/lula/blob/main/CONTRIBUTING.md) followed
